### PR TITLE
Persist settings store using Zustand

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,11 +1,33 @@
 import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
 
 interface SettingsState {
   muted: boolean
   toggleMuted: () => void
 }
 
-export const useSettings = create<SettingsState>((set) => ({
-  muted: false,
-  toggleMuted: () => set((s) => ({ muted: !s.muted })),
-}))
+export const useSettings = create<SettingsState>()(
+  persist(
+    (set) => ({
+      muted: false,
+      toggleMuted: () => set((s) => ({ muted: !s.muted })),
+    }),
+    {
+      name: 'pong-settings',
+      version: 1,
+      storage:
+        typeof window !== 'undefined'
+          ? createJSONStorage(() => localStorage)
+          : undefined,
+      migrate: (persistedState, version) => {
+        if (version === 0) {
+          return {
+            muted:
+              (persistedState as SettingsState | undefined)?.muted ?? false,
+          }
+        }
+        return persistedState as SettingsState
+      },
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- persist settings store to localStorage with unique key
- add migration scaffold for future settings changes

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881d7484483288254b1f8ff428852