### PR TITLE
feat: add service worker caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ graph LR
 - Run `pnpm prisma migrate dev` after changing the schema.
 - If Playwright tests fail, install browsers with `npx playwright install`.
 - Internationalization: currently only English is provided; add more locales under `src/locales/` as needed.
+
+## Offline Support
+
+The app registers a service worker that caches HTML, JavaScript, CSS, and game assets using a cache-first strategy.
+Assets are versioned, and outdated caches are cleared on activation, allowing the game to load and run even without a network connection after the first visit.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,50 @@
-self.addEventListener('install', () => {
+const CACHE_VERSION = 'v1'
+const CACHE_NAME = `photonpong-cache-${CACHE_VERSION}`
+const PRECACHE_URLS = ['/']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)),
+  )
   self.skipWaiting()
 })
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim())
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  )
 })
 
-self.addEventListener('fetch', () => {})
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
+
+  const url = new URL(event.request.url)
+  if (url.origin !== self.location.origin) return
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached
+
+      return fetch(event.request)
+        .then((response) => {
+          if (response.status === 200 && response.type === 'basic') {
+            const respClone = response.clone()
+            caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put(event.request, respClone))
+          }
+          return response
+        })
+        .catch(() => caches.match('/'))
+    }),
+  )
+})


### PR DESCRIPTION
## Summary
- cache HTML, JS, CSS, and game assets with a cache-first strategy
- version caches and purge outdated entries on activation
- document offline support in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881c4de0083289821bfb32b7ea56c