### PR TITLE
feat: validate environment config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@playwright/test'
+import { env } from './src/env'
 
 export default defineConfig({
   webServer: {
     command: 'pnpm dev',
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !env.CI,
     timeout: 120000,
   },
   testDir: 'e2e',

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,21 +4,22 @@ import { prisma } from '@/lib/prisma'
 import EmailProvider from 'next-auth/providers/email'
 import GithubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
+import { env } from '@/env'
 
 const handler = NextAuth({
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
+      server: env.EMAIL_SERVER,
+      from: env.EMAIL_FROM,
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
     }),
     GoogleProvider({
-      clientId: process.env.GOOGLE_ID!,
-      clientSecret: process.env.GOOGLE_SECRET!,
+      clientId: env.GOOGLE_ID,
+      clientSecret: env.GOOGLE_SECRET,
     }),
   ],
 })

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+const serverSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']),
+  EMAIL_SERVER: z.string().min(1),
+  EMAIL_FROM: z.string().email(),
+  GITHUB_ID: z.string().min(1),
+  GITHUB_SECRET: z.string().min(1),
+  GOOGLE_ID: z.string().min(1),
+  GOOGLE_SECRET: z.string().min(1),
+  UPSTASH_REDIS_URL: z.string().url(),
+  UPSTASH_REDIS_TOKEN: z.string().min(1),
+  CI: z.string().optional(),
+})
+
+const clientSchema = z.object({
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
+})
+
+const schema = serverSchema.merge(clientSchema)
+
+const _env =
+  typeof window === 'undefined'
+    ? schema.safeParse(process.env)
+    : clientSchema.safeParse(process.env)
+
+if (!_env.success) {
+  console.error(
+    '❌ Invalid environment variables:',
+    _env.error.flatten().fieldErrors,
+  )
+  throw new Error('Invalid environment variables')
+}
+
+export const env = _env.data as z.infer<typeof schema>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,11 @@
 import posthog from 'posthog-js'
+import { env } from '@/env'
 
 export function initAnalytics() {
   if (typeof window === 'undefined') return
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
   })
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client'
+import { env } from '@/env'
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
 
 export const prisma =
   globalForPrisma.prisma || new PrismaClient({ log: ['error', 'warn'] })
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,7 @@
 import { Redis } from '@upstash/redis'
+import { env } from '@/env'
 
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_URL!,
-  token: process.env.UPSTASH_REDIS_TOKEN!,
+  url: env.UPSTASH_REDIS_URL,
+  token: env.UPSTASH_REDIS_TOKEN,
 })


### PR DESCRIPTION
## Summary
- validate required environment variables with Zod
- use typed `env` object instead of `process.env`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881d2d26c8328a48ed8d08f59fa4c