### PR TITLE
feat: add posthog analytics events

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import Phaser from 'phaser'
+import { track } from '../lib/analytics'
 
 export function GameCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -9,6 +10,7 @@ export function GameCanvas() {
   useEffect(() => {
     if (!containerRef.current) return
 
+    const mode = 'local'
     const game = new Phaser.Game({
       type: Phaser.AUTO,
       parent: containerRef.current,
@@ -21,7 +23,10 @@ export function GameCanvas() {
       },
     })
 
+    track('game_start', { mode })
+
     return () => {
+      track('game_end', { mode, winner: 'none' })
       game.destroy(true)
     }
   }, [])

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,21 @@
 import posthog from 'posthog-js'
 
+let initialized = false
+
 export function initAnalytics() {
+  if (initialized) return
   if (typeof window === 'undefined') return
   const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   })
+  initialized = true
+}
+
+export function track(event: string, properties?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return
+  if (!initialized) initAnalytics()
+  if (!initialized) return
+  posthog.capture(event, properties)
 }

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { track } from '../lib/analytics'
 
 interface SettingsState {
   muted: boolean
@@ -7,5 +8,10 @@ interface SettingsState {
 
 export const useSettings = create<SettingsState>((set) => ({
   muted: false,
-  toggleMuted: () => set((s) => ({ muted: !s.muted })),
+  toggleMuted: () =>
+    set((s) => {
+      const next = !s.muted
+      track('settings_change', { setting: 'muted', value: next })
+      return { muted: next }
+    }),
 }))


### PR DESCRIPTION
## Summary
- make `initAnalytics` idempotent and add a `track` helper
- track key game lifecycle events
- send `settings_change` events on user preference updates

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689881d5bb3083288dcf6d49eec4d05c