### PR TITLE
feat: add validation and rate limiting to APIs

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -2,10 +2,15 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
-  const data = await prisma.leaderboard.findMany({
-    take: 10,
-    orderBy: { elo: 'desc' },
-    include: { user: true },
-  })
-  return NextResponse.json(data)
+  try {
+    const data = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      include: { user: true },
+    })
+    return NextResponse.json(data)
+  } catch (err) {
+    console.error('Failed to fetch leaderboard', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,11 +1,28 @@
 import { NextResponse } from 'next/server'
 import { redis } from '@/lib/redis'
+import { rateLimit } from '@/lib/rate-limit'
 
 export const runtime = 'edge'
 
-export async function POST() {
-  // Placeholder: push request into queue and return mock room id
+export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+
+  try {
+    const allowed = await rateLimit(`matchmaking:${ip}`, 5)
+    if (!allowed) {
+      return NextResponse.json({ error: 'rate_limited' }, { status: 429 })
+    }
+  } catch (err) {
+    console.error('Rate limit failed for matchmaking', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
+
   const roomId = Math.random().toString(36).slice(2, 10)
-  await redis.lpush('queue', roomId)
-  return NextResponse.json({ roomId })
+  try {
+    await redis.lpush('queue', roomId)
+    return NextResponse.json({ roomId })
+  } catch (err) {
+    console.error('Failed to enqueue matchmaking request', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
+import { rateLimit } from '@/lib/rate-limit'
 
 const bodySchema = z.object({
   matchId: z.string(),
@@ -10,15 +11,40 @@ const bodySchema = z.object({
 })
 
 export async function POST(req: Request) {
-  const json = await req.json()
-  const parsed = bodySchema.safeParse(json)
-  if (!parsed.success) {
+  let json
+  try {
+    json = await req.json()
+  } catch (err) {
+    console.error('Invalid JSON in score request', err)
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
+
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    console.error('Invalid score payload', parsed.error)
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+  try {
+    const allowed = await rateLimit(`score:${ip}`, 5)
+    if (!allowed) {
+      return NextResponse.json({ error: 'rate_limited' }, { status: 429 })
+    }
+  } catch (err) {
+    console.error('Rate limit failed for score', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
+
   const { matchId, p1Score, p2Score, winnerId } = parsed.data
-  await prisma.match.update({
-    where: { id: matchId },
-    data: { p1Score, p2Score, winnerId, endedAt: new Date() },
-  })
-  return NextResponse.json({ ok: true })
+  try {
+    await prisma.match.update({
+      where: { id: matchId },
+      data: { p1Score, p2Score, winnerId, endedAt: new Date() },
+    })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('Failed to update match score', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
+import { rateLimit } from '@/lib/rate-limit'
 
 const schema = z.object({
   eventType: z.string(),
@@ -9,11 +10,36 @@ const schema = z.object({
 })
 
 export async function POST(req: Request) {
-  const json = await req.json()
-  const parsed = schema.safeParse(json)
-  if (!parsed.success) {
+  let json
+  try {
+    json = await req.json()
+  } catch (err) {
+    console.error('Invalid JSON in telemetry request', err)
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
-  await prisma.telemetry.create({ data: parsed.data })
-  return NextResponse.json({ ok: true })
+
+  const parsed = schema.safeParse(json)
+  if (!parsed.success) {
+    console.error('Invalid telemetry payload', parsed.error)
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+  try {
+    const allowed = await rateLimit(`telemetry:${ip}`, 5)
+    if (!allowed) {
+      return NextResponse.json({ error: 'rate_limited' }, { status: 429 })
+    }
+  } catch (err) {
+    console.error('Rate limit failed for telemetry', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
+
+  try {
+    await prisma.telemetry.create({ data: parsed.data })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('Failed to record telemetry', err)
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,19 @@
+import { redis } from './redis'
+
+export async function rateLimit(
+  identifier: string,
+  limit: number,
+  windowSeconds = 60,
+): Promise<boolean> {
+  const key = `rl:${identifier}`
+  try {
+    const count = await redis.incr(key)
+    if (count === 1) {
+      await redis.expire(key, windowSeconds)
+    }
+    return count <= limit
+  } catch (err) {
+    console.error('Rate limit check failed', err)
+    throw err
+  }
+}


### PR DESCRIPTION
## Summary
- add centralized Redis-based rate limiter
- validate payloads and log invalid requests
- guard DB/Redis operations with error handling and log failures

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881d44f688328ba00a1a7ca6cb20f