### PR TITLE
Implement matchmaking queue with Prisma

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,11 +1,71 @@
 import { NextResponse } from 'next/server'
-import { redis } from '@/lib/redis'
-
-export const runtime = 'edge'
+import { prisma } from '@/lib/prisma'
+import { redis, MATCHMAKING_QUEUE } from '@/lib/redis'
 
 export async function POST() {
-  // Placeholder: push request into queue and return mock room id
-  const roomId = Math.random().toString(36).slice(2, 10)
-  await redis.lpush('queue', roomId)
-  return NextResponse.json({ roomId })
+  try {
+    const players = await redis.lpop<string[]>(MATCHMAKING_QUEUE, 2)
+    if (!players || players.length < 2) {
+      return NextResponse.json(
+        { error: 'not enough players in queue' },
+        { status: 400 },
+      )
+    }
+
+    const [p1Id, p2Id] = players
+    const match = await prisma.match.create({
+      data: {
+        mode: 'ranked',
+        p1Id,
+        p2Id,
+        p1Score: 0,
+        p2Score: 0,
+      },
+    })
+
+    return NextResponse.json({
+      matchId: match.id,
+      roles: {
+        [p1Id]: 'p1',
+        [p2Id]: 'p2',
+      },
+    })
+  } catch (err) {
+    console.error('matchmaking POST error', err)
+    return NextResponse.json(
+      { error: 'failed to create match' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const playerId = searchParams.get('playerId')
+    if (!playerId) {
+      return NextResponse.json({ error: 'playerId required' }, { status: 400 })
+    }
+
+    const match = await prisma.match.findFirst({
+      where: {
+        OR: [{ p1Id: playerId }, { p2Id: playerId }],
+        endedAt: null,
+      },
+      orderBy: { startedAt: 'desc' },
+    })
+
+    if (!match) {
+      return NextResponse.json({ status: 'pending' }, { status: 404 })
+    }
+
+    const role = match.p1Id === playerId ? 'p1' : 'p2'
+    return NextResponse.json({ matchId: match.id, role })
+  } catch (err) {
+    console.error('matchmaking GET error', err)
+    return NextResponse.json(
+      { error: 'failed to fetch match' },
+      { status: 500 },
+    )
+  }
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,5 +1,8 @@
 import { Redis } from '@upstash/redis'
 
+// Redis keys
+export const MATCHMAKING_QUEUE = 'matchmaking:queue'
+
 export const redis = new Redis({
   url: process.env.UPSTASH_REDIS_URL!,
   token: process.env.UPSTASH_REDIS_TOKEN!,


### PR DESCRIPTION
## Summary
- define `MATCHMAKING_QUEUE` key for Redis
- implement POST and GET matchmaking endpoints using Redis and Prisma
- add basic error handling for queue and Redis failures

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881e037a08328a40f79c9ca2d4553