### PR TITLE
feat: validate telemetry events

### DIFF
--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    telemetry: {
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { POST } from './route'
+import { prisma } from '@/lib/prisma'
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/telemetry', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+describe('telemetry POST handler', () => {
+  it('accepts known event with valid payload', async () => {
+    const req = makeRequest({
+      eventType: 'match_start',
+      payload: { matchId: '123' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(prisma.telemetry.create).toHaveBeenCalled()
+  })
+
+  it('rejects unknown events', async () => {
+    const req = makeRequest({ eventType: 'unknown', payload: {} })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'unknown event' })
+  })
+
+  it('rejects invalid payload', async () => {
+    const req = makeRequest({ eventType: 'match_start', payload: {} })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'invalid payload' })
+  })
+})

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
+import {
+  telemetryEventSchemas,
+  TelemetryEventType,
+} from '@/lib/telemetrySchema'
 
 const schema = z.object({
   eventType: z.string(),
-  payload: z.any(),
+  payload: z.unknown(),
   userId: z.string().optional(),
 })
 
@@ -14,6 +18,25 @@ export async function POST(req: Request) {
   if (!parsed.success) {
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
-  await prisma.telemetry.create({ data: parsed.data })
+
+  const { eventType, payload, userId } = parsed.data
+  const eventSchema = telemetryEventSchemas[eventType as TelemetryEventType]
+
+  if (!eventSchema) {
+    return NextResponse.json({ error: 'unknown event' }, { status: 400 })
+  }
+
+  const payloadParsed = eventSchema.safeParse(payload)
+  if (!payloadParsed.success) {
+    return NextResponse.json({ error: 'invalid payload' }, { status: 400 })
+  }
+
+  await prisma.telemetry.create({
+    data: {
+      eventType,
+      payload: payloadParsed.data,
+      userId,
+    },
+  })
   return NextResponse.json({ ok: true })
 }

--- a/src/lib/telemetrySchema.ts
+++ b/src/lib/telemetrySchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const telemetryEventSchemas = {
+  match_start: z.object({
+    matchId: z.string(),
+  }),
+  match_end: z.object({
+    matchId: z.string(),
+    winnerId: z.string(),
+  }),
+} as const
+
+export type TelemetryEventType = keyof typeof telemetryEventSchemas

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- define per-event telemetry Zod schemas
- validate incoming telemetry against event-specific schema and reject unknown events
- cover validation with unit tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881e578248328bed535b745bcfcaa