### PR TITLE
refactor: use official prisma types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["node", "@prisma/client"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -1,6 +1,0 @@
-declare module '@prisma/client' {
-  export class PrismaClient {
-    constructor(options?: any)
-    [key: string]: any
-  }
-}


### PR DESCRIPTION
## Summary
- remove custom Prisma client type stub
- configure tsconfig to resolve official `@prisma/client` types

## Testing
- `pnpm test`
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_689881e6eed48328ae5859cf34d802c7