### PR TITLE
feat: add offline caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ graph LR
   C --> E[(Upstash Redis)]
 ```
 
+## Offline Testing
+
+To verify the service worker's offline cache:
+
+1. Run `pnpm dev` and open the app in your browser.
+2. In DevTools, confirm the service worker is registered under **Application → Service Workers**.
+3. Switch the Network panel to **Offline** and reload the page.
+4. The app should load using cached assets even without a network connection.
+
 ## Troubleshooting
 
 - Ensure Postgres database is reachable via `DATABASE_URL`.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,8 @@
-self.addEventListener('install', () => {
+const CACHE_NAME = 'photonpong-cache-v1'
+const ASSETS = ['/', '/favicon.ico']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)))
   self.skipWaiting()
 })
 
@@ -6,4 +10,19 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim())
 })
 
-self.addEventListener('fetch', () => {})
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
+
+  const fetchPromise = fetch(event.request).then((networkResponse) =>
+    caches.open(CACHE_NAME).then((cache) => {
+      cache.put(event.request, networkResponse.clone())
+      return networkResponse
+    }),
+  )
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetchPromise),
+  )
+
+  event.waitUntil(fetchPromise)
+})


### PR DESCRIPTION
## Summary
- cache essential assets during service worker install
- serve cached responses and refresh cache in background
- document how to verify offline behavior

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881ea99248328a8200354fe1b2d94