### PR TITLE
Handle Prisma errors in API routes and add tests

### DIFF
--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+vi.mock('@/lib/prisma', () => ({
+  prisma: { leaderboard: { findMany: vi.fn() } },
+}))
+import { GET } from './route'
+import { prisma } from '@/lib/prisma'
+
+describe('Leaderboard API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 500 when Prisma throws', async () => {
+    ;(prisma.leaderboard.findMany as unknown as vi.Mock).mockRejectedValue(
+      new Error('db'),
+    )
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await GET()
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toBe('Failed to fetch leaderboard')
+    expect(errorSpy).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -2,10 +2,18 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
-  const data = await prisma.leaderboard.findMany({
-    take: 10,
-    orderBy: { elo: 'desc' },
-    include: { user: true },
-  })
-  return NextResponse.json(data)
+  try {
+    const data = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      include: { user: true },
+    })
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Failed to fetch leaderboard', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch leaderboard' },
+      { status: 500 },
+    )
+  }
 }

--- a/src/app/api/score/route.test.ts
+++ b/src/app/api/score/route.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+vi.mock('@/lib/prisma', () => ({
+  prisma: { match: { update: vi.fn() } },
+}))
+import { POST } from './route'
+import { prisma } from '@/lib/prisma'
+
+describe('Score API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 500 when Prisma throws', async () => {
+    const body = { matchId: 'm1', p1Score: 1, p2Score: 2, winnerId: 'p2' }
+    const req = new Request('http://localhost/api/score', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    ;(prisma.match.update as unknown as vi.Mock).mockRejectedValue(
+      new Error('db'),
+    )
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toBe('Failed to update match score')
+    expect(errorSpy).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -10,15 +10,23 @@ const bodySchema = z.object({
 })
 
 export async function POST(req: Request) {
-  const json = await req.json()
-  const parsed = bodySchema.safeParse(json)
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  try {
+    const json = await req.json()
+    const parsed = bodySchema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'invalid' }, { status: 400 })
+    }
+    const { matchId, p1Score, p2Score, winnerId } = parsed.data
+    await prisma.match.update({
+      where: { id: matchId },
+      data: { p1Score, p2Score, winnerId, endedAt: new Date() },
+    })
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Failed to update match score', error)
+    return NextResponse.json(
+      { error: 'Failed to update match score' },
+      { status: 500 },
+    )
   }
-  const { matchId, p1Score, p2Score, winnerId } = parsed.data
-  await prisma.match.update({
-    where: { id: matchId },
-    data: { p1Score, p2Score, winnerId, endedAt: new Date() },
-  })
-  return NextResponse.json({ ok: true })
 }

--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+vi.mock('@/lib/prisma', () => ({
+  prisma: { telemetry: { create: vi.fn() } },
+}))
+import { POST } from './route'
+import { prisma } from '@/lib/prisma'
+
+describe('Telemetry API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 500 when Prisma throws', async () => {
+    const body = { eventType: 'test', payload: {}, userId: 'u1' }
+    const req = new Request('http://localhost/api/telemetry', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    ;(prisma.telemetry.create as unknown as vi.Mock).mockRejectedValue(
+      new Error('db'),
+    )
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toBe('Failed to create telemetry')
+    expect(errorSpy).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -9,11 +9,19 @@ const schema = z.object({
 })
 
 export async function POST(req: Request) {
-  const json = await req.json()
-  const parsed = schema.safeParse(json)
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  try {
+    const json = await req.json()
+    const parsed = schema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'invalid' }, { status: 400 })
+    }
+    await prisma.telemetry.create({ data: parsed.data })
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Failed to create telemetry', error)
+    return NextResponse.json(
+      { error: 'Failed to create telemetry' },
+      { status: 500 },
+    )
   }
-  await prisma.telemetry.create({ data: parsed.data })
-  return NextResponse.json({ ok: true })
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'node:path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- wrap Prisma database calls in try/catch blocks for telemetry, score, and leaderboard routes, returning 500 responses on errors
- log route failures and surface descriptive error messages
- add Vitest unit tests for error handling and configure alias resolution

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881ecd5888328bf1b0367494f39ba