### PR TITLE
feat: centralize environment validation

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@playwright/test'
+import { CI } from './src/env'
 
 export default defineConfig({
   webServer: {
     command: 'pnpm dev',
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !CI,
     timeout: 120000,
   },
   testDir: 'e2e',

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,21 +4,29 @@ import { prisma } from '@/lib/prisma'
 import EmailProvider from 'next-auth/providers/email'
 import GithubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
+import {
+  EMAIL_SERVER,
+  EMAIL_FROM,
+  GITHUB_ID,
+  GITHUB_SECRET,
+  GOOGLE_ID,
+  GOOGLE_SECRET,
+} from '@/env'
 
 const handler = NextAuth({
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
+      server: EMAIL_SERVER,
+      from: EMAIL_FROM,
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
+      clientId: GITHUB_ID,
+      clientSecret: GITHUB_SECRET,
     }),
     GoogleProvider({
-      clientId: process.env.GOOGLE_ID!,
-      clientSecret: process.env.GOOGLE_SECRET!,
+      clientId: GOOGLE_ID,
+      clientSecret: GOOGLE_SECRET,
     }),
   ],
 })

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
+  UPSTASH_REDIS_URL: z.string().url(),
+  UPSTASH_REDIS_TOKEN: z.string(),
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
+  EMAIL_SERVER: z.string(),
+  EMAIL_FROM: z.string().email(),
+  GITHUB_ID: z.string(),
+  GITHUB_SECRET: z.string(),
+  GOOGLE_ID: z.string(),
+  GOOGLE_SECRET: z.string(),
+  CI: z.string().optional(),
+})
+
+const env = envSchema.parse(process.env)
+
+export const {
+  NODE_ENV,
+  UPSTASH_REDIS_URL,
+  UPSTASH_REDIS_TOKEN,
+  NEXT_PUBLIC_POSTHOG_KEY,
+  NEXT_PUBLIC_POSTHOG_HOST,
+  EMAIL_SERVER,
+  EMAIL_FROM,
+  GITHUB_ID,
+  GITHUB_SECRET,
+  GOOGLE_ID,
+  GOOGLE_SECRET,
+  CI,
+} = env
+
+export { envSchema }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,11 @@
 import posthog from 'posthog-js'
+import { NEXT_PUBLIC_POSTHOG_KEY, NEXT_PUBLIC_POSTHOG_HOST } from '@/env'
 
 export function initAnalytics() {
   if (typeof window === 'undefined') return
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: NEXT_PUBLIC_POSTHOG_HOST,
   })
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client'
+import { NODE_ENV } from '@/env'
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
 
 export const prisma =
   globalForPrisma.prisma || new PrismaClient({ log: ['error', 'warn'] })
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,7 @@
 import { Redis } from '@upstash/redis'
+import { UPSTASH_REDIS_URL, UPSTASH_REDIS_TOKEN } from '@/env'
 
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_URL!,
-  token: process.env.UPSTASH_REDIS_TOKEN!,
+  url: UPSTASH_REDIS_URL,
+  token: UPSTASH_REDIS_TOKEN,
 })


### PR DESCRIPTION
## Summary
- add Zod-based env schema and validation
- replace inline `process.env` lookups with env imports
- allow Playwright config to reuse server based on env

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689881f3f4c8832894754f30dcf68d82