### PR TITLE
chore: generate prisma client in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install
+      - run: npx prisma generate
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test

--- a/amplify.yml
+++ b/amplify.yml
@@ -9,6 +9,7 @@ applications:
         preBuild:
           commands:
             - pnpm install
+            - npx prisma generate
         build:
           commands:
             - pnpm build

--- a/cloudflare-pages.yml
+++ b/cloudflare-pages.yml
@@ -1,4 +1,4 @@
 # Cloudflare Pages build configuration
 build:
-  command: pnpm build
+  command: npx prisma generate && pnpm build
   directory: .next

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -1,6 +1,0 @@
-declare module '@prisma/client' {
-  export class PrismaClient {
-    constructor(options?: any)
-    [key: string]: any
-  }
-}


### PR DESCRIPTION
## Summary
- remove manual Prisma type stub
- run `npx prisma generate` in CI builds

## Testing
- `npx prisma generate` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881f4c60083288f591a3610f13b6d