### PR TITLE
Secure API routes with auth checks and tests

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,26 +1,6 @@
 import NextAuth from 'next-auth'
-import { PrismaAdapter } from '@auth/prisma-adapter'
-import { prisma } from '@/lib/prisma'
-import EmailProvider from 'next-auth/providers/email'
-import GithubProvider from 'next-auth/providers/github'
-import GoogleProvider from 'next-auth/providers/google'
+import { authOptions } from '@/lib/auth'
 
-const handler = NextAuth({
-  adapter: PrismaAdapter(prisma),
-  providers: [
-    EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
-    }),
-    GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
-    }),
-    GoogleProvider({
-      clientId: process.env.GOOGLE_ID!,
-      clientSecret: process.env.GOOGLE_SECRET!,
-    }),
-  ],
-})
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }

--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+vi.mock('@/lib/prisma', () => ({
+  prisma: { leaderboard: { findMany: vi.fn() } },
+}))
+
+import { GET } from './route'
+import { prisma } from '@/lib/prisma'
+import { getServerSession } from 'next-auth'
+
+describe('GET /api/leaderboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns leaderboard data', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.leaderboard.findMany).mockResolvedValue([
+      {
+        elo: 1000,
+        wins: 1,
+        losses: 0,
+        streak: 1,
+        user: { id: '1', name: 'Alice' },
+      },
+    ])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual([
+      {
+        elo: 1000,
+        wins: 1,
+        losses: 0,
+        streak: 1,
+        user: { id: '1', name: 'Alice' },
+      },
+    ])
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 500 on db error', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.leaderboard.findMany).mockRejectedValue(new Error('db'))
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,11 +1,27 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export async function GET() {
-  const data = await prisma.leaderboard.findMany({
-    take: 10,
-    orderBy: { elo: 'desc' },
-    include: { user: true },
-  })
-  return NextResponse.json(data)
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  try {
+    const data = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      select: {
+        elo: true,
+        wins: true,
+        losses: true,
+        streak: true,
+        user: { select: { id: true, name: true } },
+      },
+    })
+    return NextResponse.json(data)
+  } catch (_error) {
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+vi.mock('@/lib/redis', () => ({ redis: { lpush: vi.fn() } }))
+vi.mock('@/lib/prisma', () => ({ prisma: {} }))
+
+import { POST } from './route'
+import { redis } from '@/lib/redis'
+import { getServerSession } from 'next-auth'
+
+describe('POST /api/matchmaking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queues matchmaking request', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(redis.lpush).mockResolvedValue(1 as any)
+    vi.spyOn(Math, 'random').mockReturnValue(0.1)
+    const res = await POST()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.roomId).toBe('3lllllll') // Math.random=0.1
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(redis.lpush).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on redis error', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(redis.lpush).mockRejectedValue(new Error('redis'))
+    const res = await POST()
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,11 +1,21 @@
 import { NextResponse } from 'next/server'
 import { redis } from '@/lib/redis'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export const runtime = 'edge'
 
 export async function POST() {
-  // Placeholder: push request into queue and return mock room id
-  const roomId = Math.random().toString(36).slice(2, 10)
-  await redis.lpush('queue', roomId)
-  return NextResponse.json({ roomId })
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  try {
+    // Placeholder: push request into queue and return mock room id
+    const roomId = Math.random().toString(36).slice(2, 10)
+    await redis.lpush('queue', roomId)
+    return NextResponse.json({ roomId })
+  } catch (_error) {
+    return NextResponse.json({ error: 'internal' }, { status: 500 })
+  }
 }

--- a/src/app/api/score/route.test.ts
+++ b/src/app/api/score/route.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+vi.mock('@/lib/prisma', () => ({ prisma: { match: { update: vi.fn() } } }))
+
+import { POST } from './route'
+import { prisma } from '@/lib/prisma'
+import { getServerSession } from 'next-auth'
+
+describe('POST /api/score', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const body = { matchId: '1', p1Score: 5, p2Score: 3, winnerId: '1' }
+
+  it('updates match score', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.match.update).mockResolvedValue({} as any)
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ ok: true })
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+    expect(prisma.match.update).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on db error', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.match.update).mockRejectedValue(new Error('db'))
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+vi.mock('@/lib/prisma', () => ({ prisma: { telemetry: { create: vi.fn() } } }))
+
+import { POST } from './route'
+import { prisma } from '@/lib/prisma'
+import { getServerSession } from 'next-auth'
+
+describe('POST /api/telemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const body = { eventType: 'test', payload: { foo: 'bar' } }
+
+  it('stores telemetry', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.telemetry.create).mockResolvedValue({} as any)
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ ok: true })
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+    expect(prisma.telemetry.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on db error', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } } as any)
+    vi.mocked(prisma.telemetry.create).mockRejectedValue(new Error('db'))
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { PrismaAdapter } from '@auth/prisma-adapter'
+import EmailProvider from 'next-auth/providers/email'
+import GithubProvider from 'next-auth/providers/github'
+import GoogleProvider from 'next-auth/providers/google'
+import type { NextAuthOptions } from 'next-auth'
+import { prisma } from './prisma'
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    EmailProvider({
+      server: process.env.EMAIL_SERVER || '',
+      from: process.env.EMAIL_FROM || '',
+    }),
+    GithubProvider({
+      clientId: process.env.GITHUB_ID || '',
+      clientSecret: process.env.GITHUB_SECRET || '',
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_ID || '',
+      clientSecret: process.env.GOOGLE_SECRET || '',
+    }),
+  ],
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
   test: {
@@ -6,5 +7,10 @@ export default defineConfig({
     globals: true,
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+vi.mock('next-auth/providers/email', () => ({ default: () => ({}) }))
+vi.mock('next-auth/providers/github', () => ({ default: () => ({}) }))
+vi.mock('next-auth/providers/google', () => ({ default: () => ({}) }))


### PR DESCRIPTION
## Summary
- centralize NextAuth config and use `getServerSession` in API routes
- add error handling and sanitize leaderboard fields
- expand Vitest configuration and add unit tests for success, unauthorized, and failure scenarios

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881f67e7c83288ae4ab7dca789ec4