### PR TITLE
feat: persist settings

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,11 +1,28 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 interface SettingsState {
   muted: boolean
   toggleMuted: () => void
 }
 
-export const useSettings = create<SettingsState>((set) => ({
-  muted: false,
-  toggleMuted: () => set((s) => ({ muted: !s.muted })),
-}))
+export const useSettings = create<SettingsState>()(
+  persist(
+    (set) => ({
+      muted: false,
+      toggleMuted: () => set((s) => ({ muted: !s.muted })),
+    }),
+    {
+      name: 'settings',
+      version: 1,
+      migrate: (persistedState, version) => {
+        switch (version) {
+          case 0:
+            return { muted: (persistedState as any)?.muted ?? false }
+          default:
+            return persistedState as SettingsState
+        }
+      },
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- persist settings store with zustand's middleware and support migrations

## Testing
- `pnpm lint src/store/settings.ts` *(fails: > Couldn't find any `pages` or `app` directory)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881f9fa948328aa8c412909db824e