### PR TITLE
feat: add PostHog event tracking helpers

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+import { trackLeaderboardView } from '../../lib/events'
+
+export default function LeaderboardPage() {
+  useEffect(() => {
+    trackLeaderboardView()
+  }, [])
+  return <div>Leaderboard</div>
+}

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import Phaser from 'phaser'
+import { trackGameStart, trackGameEnd } from '../lib/events'
 
 export function GameCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -9,6 +10,7 @@ export function GameCanvas() {
   useEffect(() => {
     if (!containerRef.current) return
 
+    trackGameStart('classic')
     const game = new Phaser.Game({
       type: Phaser.AUTO,
       parent: containerRef.current,
@@ -22,6 +24,7 @@ export function GameCanvas() {
     })
 
     return () => {
+      trackGameEnd('classic', 'player')
       game.destroy(true)
     }
   }, [])

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('posthog-js', () => ({ default: { capture: vi.fn() } }))
+import posthog from 'posthog-js'
+const capture = posthog.capture as ReturnType<typeof vi.fn>
+
+import {
+  trackGameStart,
+  trackGameEnd,
+  trackLeaderboardView,
+  trackMatchmakingStart,
+  trackMatchmakingSuccess,
+  trackSettingsChange,
+  trackPwaInstall,
+} from './events'
+
+describe('events', () => {
+  beforeEach(() => {
+    capture.mockClear()
+  })
+
+  test('trackGameStart', () => {
+    trackGameStart('classic')
+    expect(capture).toHaveBeenCalledWith('game_start', { mode: 'classic' })
+  })
+
+  test('trackGameEnd', () => {
+    trackGameEnd('classic', 'player')
+    expect(capture).toHaveBeenCalledWith('game_end', {
+      mode: 'classic',
+      winner: 'player',
+    })
+  })
+
+  test('trackLeaderboardView', () => {
+    trackLeaderboardView()
+    expect(capture).toHaveBeenCalledWith('leaderboard_view')
+  })
+
+  test('trackMatchmakingStart', () => {
+    trackMatchmakingStart('classic')
+    expect(capture).toHaveBeenCalledWith('matchmaking_start', {
+      mode: 'classic',
+    })
+  })
+
+  test('trackMatchmakingSuccess', () => {
+    trackMatchmakingSuccess('classic', 42)
+    expect(capture).toHaveBeenCalledWith('matchmaking_success', {
+      mode: 'classic',
+      duration: 42,
+    })
+  })
+
+  test('trackSettingsChange', () => {
+    trackSettingsChange('sound', 'on')
+    expect(capture).toHaveBeenCalledWith('settings_change', {
+      setting: 'sound',
+      value: 'on',
+    })
+  })
+
+  test('trackPwaInstall', () => {
+    trackPwaInstall()
+    expect(capture).toHaveBeenCalledWith('pwa_install')
+  })
+})

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,29 @@
+import posthog from 'posthog-js'
+
+export function trackGameStart(mode: string) {
+  posthog.capture('game_start', { mode })
+}
+
+export function trackGameEnd(mode: string, winner: string) {
+  posthog.capture('game_end', { mode, winner })
+}
+
+export function trackLeaderboardView() {
+  posthog.capture('leaderboard_view')
+}
+
+export function trackMatchmakingStart(mode: string) {
+  posthog.capture('matchmaking_start', { mode })
+}
+
+export function trackMatchmakingSuccess(mode: string, duration: number) {
+  posthog.capture('matchmaking_success', { mode, duration })
+}
+
+export function trackSettingsChange(setting: string, value: string) {
+  posthog.capture('settings_change', { setting, value })
+}
+
+export function trackPwaInstall() {
+  posthog.capture('pwa_install')
+}


### PR DESCRIPTION
## Summary
- add PostHog event helper wrappers
- track gameplay and leaderboard views
- test PostHog event payloads with mocks

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689881fadf98832895a2d9e6d44739e7