### PR TITLE
chore: clean up prisma stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "e2e": "playwright test",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "prisma db seed",
+    "postinstall": "prisma generate",
     "prepare": "simple-git-hooks"
   },
   "dependencies": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
-import { PrismaClient } from '@prisma/client'
+import pkg from '@prisma/client'
 
+const PrismaClient = (pkg as any).PrismaClient
 const prisma = new PrismaClient()
 
 async function main() {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,6 +1,7 @@
-import { PrismaClient } from '@prisma/client'
+import pkg from '@prisma/client'
 
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+const PrismaClient = (pkg as any).PrismaClient
+const globalForPrisma = globalThis as unknown as { prisma?: any }
 
 export const prisma =
   globalForPrisma.prisma || new PrismaClient({ log: ['error', 'warn'] })

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -1,6 +1,0 @@
-declare module '@prisma/client' {
-  export class PrismaClient {
-    constructor(options?: any)
-    [key: string]: any
-  }
-}


### PR DESCRIPTION
## Summary
- remove custom Prisma client stub and use real package import
- generate Prisma client on install with new postinstall script
- adjust seed and Prisma helper to import from `@prisma/client`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/s/geistmono/...`)*
- `pnpm test`
- `pnpm prisma generate` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68988207def88328bd13ef9eff321922