### PR TITLE
Implement authenticated Redis matchmaking with tests

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,7 +5,7 @@ import EmailProvider from 'next-auth/providers/email'
 import GithubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
 
-const handler = NextAuth({
+export const authOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
@@ -21,6 +21,8 @@ const handler = NextAuth({
       clientSecret: process.env.GOOGLE_SECRET!,
     }),
   ],
-})
+}
+
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }

--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+vi.mock('../auth/[...nextauth]/route', () => ({ authOptions: {} }), {
+  virtual: true,
+})
+
+vi.mock('@/lib/redis', () => {
+  const queues = new Map<string, string[]>()
+  const waiters = new Map<string, ((v: [string, string]) => void)[]>()
+
+  function resolve(key: string, value: string) {
+    const res = waiters.get(key)?.shift()
+    if (res) res([key, value])
+  }
+
+  return {
+    redis: {
+      lpush: vi.fn(async (key: string, value: string) => {
+        const q = queues.get(key) ?? []
+        q.unshift(value)
+        queues.set(key, q)
+        const waiter = waiters.get(key)?.shift()
+        if (waiter) {
+          const v = q.pop()!
+          waiter([key, v])
+        }
+      }),
+      rpop: vi.fn(async (key: string) => {
+        const q = queues.get(key)
+        return q && q.length ? q.pop()! : null
+      }),
+      brpop: vi.fn(async (key: string) => {
+        const q = queues.get(key)
+        if (q && q.length) return [key, q.pop()!]
+        return new Promise<[string, string]>((res) => {
+          const arr = waiters.get(key) ?? []
+          arr.push(res)
+          waiters.set(key, arr)
+        })
+      }),
+      __queues: queues,
+      __reset: () => {
+        queues.clear()
+        waiters.clear()
+      },
+    },
+  }
+})
+
+import { POST } from './route'
+import { redis } from '@/lib/redis'
+import { getServerSession } from 'next-auth'
+
+describe('matchmaking', () => {
+  beforeEach(() => {
+    ;(redis as any).__reset()
+    ;(getServerSession as any).mockReset()
+  })
+
+  it('queues single user until opponent joins', async () => {
+    ;(getServerSession as any).mockResolvedValueOnce({ user: { id: 'alice' } })
+    const first = POST()
+
+    // ensure first user is queued
+    await new Promise((r) => setTimeout(r, 0))
+    expect((redis as any).__queues.get('matchmaking')).toEqual(['alice'])
+    ;(getServerSession as any).mockResolvedValueOnce({ user: { id: 'bob' } })
+    const second = POST()
+
+    const [res1, res2] = await Promise.all([first, second])
+    const data1 = await res1.json()
+    const data2 = await res2.json()
+    expect(data1).toMatchObject({ opponentId: 'bob' })
+    expect(data2).toMatchObject({ opponentId: 'alice' })
+    expect(data1.roomId).toBe(data2.roomId)
+  })
+
+  it('pairs simultaneous matchmaking requests', async () => {
+    ;(getServerSession as any).mockResolvedValueOnce({ user: { id: 'carol' } })
+    const p1 = POST()
+    await new Promise((r) => setTimeout(r, 0))
+    ;(getServerSession as any).mockResolvedValueOnce({ user: { id: 'dave' } })
+    const p2 = POST()
+
+    const [res1, res2] = await Promise.all([p1, p2])
+    const data1 = await res1.json()
+    const data2 = await res2.json()
+    expect(data1).toMatchObject({ opponentId: 'dave' })
+    expect(data2).toMatchObject({ opponentId: 'carol' })
+    expect(data1.roomId).toBe(data2.roomId)
+  })
+})

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,11 +1,28 @@
 import { NextResponse } from 'next/server'
 import { redis } from '@/lib/redis'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]/route'
 
 export const runtime = 'edge'
 
 export async function POST() {
-  // Placeholder: push request into queue and return mock room id
-  const roomId = Math.random().toString(36).slice(2, 10)
-  await redis.lpush('queue', roomId)
-  return NextResponse.json({ roomId })
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+  if (!userId)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const opponentId = await redis.rpop('matchmaking')
+
+  if (opponentId) {
+    const roomId = [userId, opponentId].sort().join(':')
+    await redis.lpush(
+      `match:${opponentId}`,
+      JSON.stringify({ roomId, opponentId: userId }),
+    )
+    return NextResponse.json({ roomId, opponentId })
+  }
+
+  await redis.lpush('matchmaking', userId)
+  const [, data] = await redis.brpop(`match:${userId}`, 0)
+  return NextResponse.json(JSON.parse(data))
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- export NextAuth options for server-side session access
- implement user-based matchmaking queue that returns opponent and room info
- add Vitest path alias and tests for queuing and concurrent matchmaking

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689882009c3c8328b5575e1aa110dcee