### PR TITLE
Add leaderboard page with navigation and tests

### DIFF
--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+test('leaderboard displays top players', async ({ page }) => {
+  await page.goto('http://localhost:3000/leaderboard')
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
+  await expect(page.getByRole('cell', { name: 'Alice' })).toBeVisible()
+  await expect(page.getByRole('cell', { name: 'Bob' })).toBeVisible()
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Script from 'next/script'
+import Link from 'next/link'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { AnalyticsProvider } from '../components/AnalyticsProvider'
@@ -30,6 +31,12 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <AnalyticsProvider />
+        <header className="border-b p-4">
+          <nav className="flex gap-4">
+            <Link href="/">Home</Link>
+            <Link href="/leaderboard">Leaderboard</Link>
+          </nav>
+        </header>
         {children}
         <Script id="sw" strategy="afterInteractive">
           {`

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+interface LeaderboardEntry {
+  userId: string
+  elo: number
+  user: {
+    name: string | null
+  }
+}
+
+export default async function LeaderboardPage() {
+  const res = await fetch('http://localhost:3000/api/leaderboard', {
+    cache: 'no-store',
+  })
+  const data: LeaderboardEntry[] = await res.json()
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Leaderboard</h1>
+      <table className="min-w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">Rank</th>
+            <th className="px-4 py-2 text-left">Username</th>
+            <th className="px-4 py-2 text-left">ELO</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((entry, index) => (
+            <tr key={entry.userId}>
+              <td className="border-t px-4 py-2">{index + 1}</td>
+              <td className="border-t px-4 py-2">
+                {entry.user.name || 'Unknown'}
+              </td>
+              <td className="border-t px-4 py-2">{entry.elo}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4">
+        <Link href="/">Back to game</Link>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add leaderboard page fetching `/api/leaderboard` and rendering rank, username, and ELO
- add header navigation linking to new page
- add Playwright spec to verify top players show on leaderboard

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689882079fd48328bc55cbe1bbb172c1