### PR TITLE
feat: update leaderboard after match

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/prisma'
+import { applyMatch } from '@/lib/elo'
 
 const bodySchema = z.object({
   matchId: z.string(),
@@ -16,9 +17,23 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'invalid' }, { status: 400 })
   }
   const { matchId, p1Score, p2Score, winnerId } = parsed.data
-  await prisma.match.update({
-    where: { id: matchId },
-    data: { p1Score, p2Score, winnerId, endedAt: new Date() },
+  await prisma.$transaction(async (tx) => {
+    const match = await tx.match.update({
+      where: { id: matchId },
+      data: { p1Score, p2Score, winnerId, endedAt: new Date() },
+    })
+    const players = [match.p1Id, match.p2Id].filter(Boolean) as string[]
+    const leaderboards = await tx.leaderboard.findMany({
+      where: { userId: { in: players } },
+    })
+    const p1Board = leaderboards.find((l) => l.userId === match.p1Id)!
+    const p2Board = leaderboards.find((l) => l.userId === match.p2Id)!
+    const winner = winnerId === match.p1Id ? 'p1' : 'p2'
+    const { p1, p2 } = applyMatch(p1Board, p2Board, winner)
+    await Promise.all([
+      tx.leaderboard.update({ where: { userId: match.p1Id }, data: p1 }),
+      tx.leaderboard.update({ where: { userId: match.p2Id! }, data: p2 }),
+    ])
   })
   return NextResponse.json({ ok: true })
 }

--- a/src/lib/elo.ts
+++ b/src/lib/elo.ts
@@ -1,0 +1,64 @@
+export interface LeaderboardStats {
+  elo: number
+  wins: number
+  losses: number
+  streak: number
+}
+
+function expectedScore(rating: number, opponentRating: number) {
+  return 1 / (1 + Math.pow(10, (opponentRating - rating) / 400))
+}
+
+export function calculateElo(
+  p1Elo: number,
+  p2Elo: number,
+  winner: 'p1' | 'p2',
+  k = 32,
+) {
+  const exp1 = expectedScore(p1Elo, p2Elo)
+  const exp2 = expectedScore(p2Elo, p1Elo)
+  const score1 = winner === 'p1' ? 1 : 0
+  const score2 = winner === 'p2' ? 1 : 0
+  return {
+    p1: Math.round(p1Elo + k * (score1 - exp1)),
+    p2: Math.round(p2Elo + k * (score2 - exp2)),
+  }
+}
+
+export function applyMatch(
+  p1: LeaderboardStats,
+  p2: LeaderboardStats,
+  winner: 'p1' | 'p2',
+) {
+  const { p1: p1Elo, p2: p2Elo } = calculateElo(p1.elo, p2.elo, winner)
+  const p1Win = winner === 'p1'
+  const p2Win = winner === 'p2'
+  const p1Streak = p1Win
+    ? p1.streak >= 0
+      ? p1.streak + 1
+      : 1
+    : p1.streak <= 0
+      ? p1.streak - 1
+      : -1
+  const p2Streak = p2Win
+    ? p2.streak >= 0
+      ? p2.streak + 1
+      : 1
+    : p2.streak <= 0
+      ? p2.streak - 1
+      : -1
+  return {
+    p1: {
+      elo: p1Elo,
+      wins: p1Win ? p1.wins + 1 : p1.wins,
+      losses: p1Win ? p1.losses : p1.losses + 1,
+      streak: p1Streak,
+    },
+    p2: {
+      elo: p2Elo,
+      wins: p2Win ? p2.wins + 1 : p2.wins,
+      losses: p2Win ? p2.losses : p2.losses + 1,
+      streak: p2Streak,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add ELO helper to compute rating, wins, losses, and streak
- update score API to recalc leaderboard inside a transaction

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68988a23e6408328aae204d0351eb49d