### PR TITLE
feat: add Mode enum for matches

### DIFF
--- a/docs/posthog-events.md
+++ b/docs/posthog-events.md
@@ -1,11 +1,16 @@
 # PostHog Event Plan
 
-| Event                 | Properties         | Description                |
-| --------------------- | ------------------ | -------------------------- |
-| `game_start`          | `mode`             | Fired when a game begins   |
-| `game_end`            | `mode`, `winner`   | Fired when a game ends     |
-| `leaderboard_view`    | –                  | User views leaderboard     |
-| `matchmaking_start`   | `mode`             | User initiates matchmaking |
-| `matchmaking_success` | `mode`, `duration` | Matchmaking completed      |
-| `settings_change`     | `setting`, `value` | User updates a setting     |
-| `pwa_install`         | –                  | App installed as PWA       |
+| Event                 | Properties                  | Description                |
+| --------------------- | --------------------------- | -------------------------- |
+| `game_start`          | `mode` (`Mode`)             | Fired when a game begins   |
+| `game_end`            | `mode` (`Mode`), `winner`   | Fired when a game ends     |
+| `leaderboard_view`    | –                           | User views leaderboard     |
+| `matchmaking_start`   | `mode` (`Mode`)             | User initiates matchmaking |
+| `matchmaking_success` | `mode` (`Mode`), `duration` | Matchmaking completed      |
+| `settings_change`     | `setting`, `value`          | User updates a setting     |
+| `pwa_install`         | –                           | App installed as PWA       |
+
+`Mode` enum values:
+
+- `SINGLEPLAYER`
+- `MULTIPLAYER`

--- a/prisma/migrations/20250810120531_add-mode-enum/migration.sql
+++ b/prisma/migrations/20250810120531_add-mode-enum/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "Mode" AS ENUM ('SINGLEPLAYER', 'MULTIPLAYER');
+
+-- AlterTable
+ALTER TABLE "Match" ADD COLUMN "mode_temp" "Mode";
+UPDATE "Match" SET "mode_temp" = CASE "mode"
+    WHEN 'singleplayer' THEN 'SINGLEPLAYER'
+    WHEN 'multiplayer' THEN 'MULTIPLAYER'
+    ELSE NULL
+END;
+ALTER TABLE "Match" DROP COLUMN "mode";
+ALTER TABLE "Match" RENAME COLUMN "mode_temp" TO "mode";

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,11 +26,16 @@ model Profile {
   avatarUrl   String?
 }
 
+enum Mode {
+  SINGLEPLAYER
+  MULTIPLAYER
+}
+
 model Match {
   id        String   @id @default(cuid())
   startedAt DateTime @default(now())
   endedAt   DateTime?
-  mode      String
+  mode      Mode
   p1        User     @relation("MatchP1", fields: [p1Id], references: [id])
   p1Id      String
   p2        User?    @relation("MatchP2", fields: [p2Id], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Mode } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
@@ -27,7 +27,7 @@ async function main() {
 
   await prisma.match.create({
     data: {
-      mode: 'singleplayer',
+      mode: Mode.SINGLEPLAYER,
       p1Id: alice.id,
       p2Id: bob.id,
       p1Score: 11,


### PR DESCRIPTION
## Summary
- define `Mode` enum for match type and use it in Prisma schema
- adjust seed data and analytics docs to reference `Mode.SINGLEPLAYER`/`MULTIPLAYER`
- add migration to create enum and convert match table

## Testing
- `pnpm prisma migrate dev --name add-mode-enum` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68988a256cc08328832c743e839d9ebf