### PR TITLE
feat: index telemetry

### DIFF
--- a/prisma/migrations/20250810210000_add_telemetry_indexes/migration.sql
+++ b/prisma/migrations/20250810210000_add_telemetry_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "Telemetry_eventType_idx" ON "Telemetry"("eventType");
+
+-- CreateIndex
+CREATE INDEX "Telemetry_createdAt_idx" ON "Telemetry"("createdAt");

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,4 +58,7 @@ model Telemetry {
   eventType String
   payload   Json
   createdAt DateTime @default(now())
+
+  @@index([eventType])
+  @@index([createdAt])
 }

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -17,3 +17,26 @@ export async function POST(req: Request) {
   await prisma.telemetry.create({ data: parsed.data })
   return NextResponse.json({ ok: true })
 }
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const eventType = searchParams.get('eventType')
+  const since = searchParams.get('since')
+
+  const where: Record<string, unknown> = {}
+  if (eventType) where.eventType = eventType
+  if (since) {
+    const date = new Date(since)
+    if (!isNaN(date.getTime())) {
+      where.createdAt = { gte: date }
+    }
+  }
+
+  const data = await prisma.telemetry.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+
+  return NextResponse.json(data)
+}


### PR DESCRIPTION
## Summary
- index telemetry eventType and createdAt
- expose telemetry reporting query with eventType/since filters

## Testing
- `pnpm prisma migrate dev --name add-telemetry-indexes` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `sudo -u postgres psql -d pong -c '\d "Telemetry"'`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689906120ee483289946bc6db0a5069f