### PR TITLE
Add API route and settings store tests with request helpers

### DIFF
--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('../../../lib/redis', () => ({
+  redis: {
+    lpush: vi.fn(),
+  },
+}))
+
+import { redis } from '../../../lib/redis'
+
+describe('matchmaking API', () => {
+  it('enqueues request and returns room id', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456789)
+
+    const res = await POST()
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ roomId: '4fzzzxjy' })
+    expect(redis.lpush).toHaveBeenCalledWith('queue', '4fzzzxjy')
+  })
+})

--- a/src/app/api/score/route.test.ts
+++ b/src/app/api/score/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    match: { update: vi.fn() },
+  },
+}))
+
+import { prisma } from '../../../lib/prisma'
+
+describe('score API', () => {
+  it('updates match score', async () => {
+    const body = {
+      matchId: 'm1',
+      p1Score: 10,
+      p2Score: 5,
+      winnerId: 'p1',
+    }
+
+    const res = await POST(jsonRequest(body))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ ok: true })
+    expect(prisma.match.update).toHaveBeenCalledWith({
+      where: { id: 'm1' },
+      data: {
+        p1Score: 10,
+        p2Score: 5,
+        winnerId: 'p1',
+        endedAt: expect.any(Date),
+      },
+    })
+  })
+
+  it('rejects invalid payload', async () => {
+    const res = await POST(jsonRequest({}))
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'invalid' })
+    expect(prisma.match.update).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    telemetry: { create: vi.fn() },
+  },
+}))
+
+import { prisma } from '../../../lib/prisma'
+
+describe('telemetry API', () => {
+  it('stores telemetry events', async () => {
+    const body = { eventType: 'start', payload: { foo: 'bar' }, userId: 'u1' }
+
+    const res = await POST(jsonRequest(body))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ ok: true })
+    expect(prisma.telemetry.create).toHaveBeenCalledWith({ data: body })
+  })
+
+  it('rejects invalid payload', async () => {
+    const res = await POST(jsonRequest({}))
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'invalid' })
+    expect(prisma.telemetry.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/store/settings.test.ts
+++ b/src/store/settings.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSettings } from './settings'
+
+beforeEach(() => {
+  useSettings.persist.clearStorage()
+  localStorage.clear()
+  useSettings.setState({ muted: false })
+})
+
+describe('settings store', () => {
+  it('toggles muted flag and persists', () => {
+    expect(useSettings.getState().muted).toBe(false)
+    useSettings.getState().toggleMuted()
+    expect(useSettings.getState().muted).toBe(true)
+    expect(JSON.parse(localStorage.getItem('settings')!).state.muted).toBe(true)
+  })
+
+  it('rehydrates state from storage', async () => {
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({ state: { muted: true }, version: 0 }),
+    )
+
+    await useSettings.persist.rehydrate()
+    expect(useSettings.getState().muted).toBe(true)
+  })
+})

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,11 +1,17 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 interface SettingsState {
   muted: boolean
   toggleMuted: () => void
 }
 
-export const useSettings = create<SettingsState>((set) => ({
-  muted: false,
-  toggleMuted: () => set((s) => ({ muted: !s.muted })),
-}))
+export const useSettings = create<SettingsState>()(
+  persist(
+    (set) => ({
+      muted: false,
+      toggleMuted: () => set((s) => ({ muted: !s.muted })),
+    }),
+    { name: 'settings' },
+  ),
+)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import path from 'node:path'
 
 export default defineConfig({
   test: {
@@ -6,5 +7,10 @@ export default defineConfig({
     globals: true,
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,26 @@
 import '@testing-library/jest-dom'
+import { afterEach, vi } from 'vitest'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function jsonRequest(body: unknown, init: RequestInit = {}) {
+  return new Request('http://localhost/api', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    ...init,
+  })
+}
+
+// expose helper globally for tests
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(globalThis as any).jsonRequest = jsonRequest
+
+export {}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var jsonRequest: typeof jsonRequest
+}


### PR DESCRIPTION
## Summary
- persist settings store using Zustand middleware
- add global `jsonRequest` helper and mock cleanup in test setup
- cover telemetry, score, and matchmaking API routes with Vitest
- verify settings store toggling and rehydration

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68990612f874832886c868a626d7238c