### PR TITLE
chore: remove prisma type stub

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -4,5 +4,3 @@ import { getServerAuthSession } from '@/lib/auth'
 import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
-
-}

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -1,6 +1,0 @@
-declare module '@prisma/client' {
-  export class PrismaClient {
-    constructor(options?: any)
-    [key: string]: any
-  }
-}


### PR DESCRIPTION
## Summary
- remove custom Prisma client type stub
- clean up stray code in matchmaking route

## Testing
- `pnpm prisma generate` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/.../schema-engine.gz - 403 Forbidden)*
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module 'nodemailer'; Failed to parse URL from /pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e099e488328b89e04ee5cf3be43