### PR TITLE
Add environment validation and tests

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,12 @@
 import posthog from 'posthog-js'
 
+import { env } from '@/lib/env'
+
 export function initAnalytics() {
   if (typeof window === 'undefined') return
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
   })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,20 +4,21 @@ import GithubProvider from 'next-auth/providers/github'
 import EmailProvider from 'next-auth/providers/email'
 
 import { prisma } from '@/lib/prisma'
+import { env } from '@/lib/env'
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
+      server: env.EMAIL_SERVER,
+      from: env.EMAIL_FROM,
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
     }),
   ],
-  secret: process.env.AUTH_SECRET,
+  secret: env.AUTH_SECRET,
 }
 
 export const getServerAuthSession = () => getServerSession(authOptions)

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, afterAll, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = process.env
+
+const baseEnv: NodeJS.ProcessEnv = {
+  NEXT_PUBLIC_POSTHOG_KEY: 'ph_key',
+  NEXT_PUBLIC_POSTHOG_HOST: 'https://app.posthog.com',
+  EMAIL_SERVER: 'smtp://user:pass@localhost',
+  EMAIL_FROM: 'noreply@example.com',
+  GITHUB_ID: 'id',
+  GITHUB_SECRET: 'secret',
+  AUTH_SECRET: 'secret',
+  UPSTASH_REDIS_URL: 'https://redis.example.com',
+  UPSTASH_REDIS_TOKEN: 'token',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...baseEnv }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('env validation', () => {
+  it('throws when required env var is missing', async () => {
+    delete process.env.EMAIL_SERVER
+    await expect(import('./env')).rejects.toThrow(/EMAIL_SERVER/)
+  })
+
+  it('throws when env var fails validation', async () => {
+    process.env.UPSTASH_REDIS_URL = 'not-a-url'
+    await expect(import('./env')).rejects.toThrow(/UPSTASH_REDIS_URL/)
+  })
+})

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
+  EMAIL_SERVER: z.string(),
+  EMAIL_FROM: z.string().email(),
+  GITHUB_ID: z.string(),
+  GITHUB_SECRET: z.string(),
+  AUTH_SECRET: z.string(),
+  UPSTASH_REDIS_URL: z.string().url(),
+  UPSTASH_REDIS_TOKEN: z.string(),
+})
+
+const parsed = envSchema.safeParse(process.env)
+
+if (!parsed.success) {
+  const errors = parsed.error.flatten().fieldErrors
+  const formatted = Object.entries(errors)
+    .map(([name, issues]) => `${name}: ${issues?.join(', ')}`)
+    .join('\n')
+  throw new Error(`Invalid environment variables:\n${formatted}`)
+}
+
+export const env = parsed.data

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,8 @@
 import { Redis } from '@upstash/redis'
 
+import { env } from '@/lib/env'
+
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_URL!,
-  token: process.env.UPSTASH_REDIS_TOKEN!,
+  url: env.UPSTASH_REDIS_URL,
+  token: env.UPSTASH_REDIS_TOKEN,
 })


### PR DESCRIPTION
## Summary
- centralize environment variable parsing with zod
- use validated env in auth, redis, and analytics modules
- test that missing or invalid env vars produce clear errors

## Testing
- `pnpm test src/lib/env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a8e0700c08328b3b36622d2d3d0b9