### PR TITLE
test: add matchmaking API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "posthog-js": "^1.258.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "zod": "^4.0.15",
+    "zod": "^3.23.8",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       zod:
-        specifier: ^4.0.15
-        version: 4.0.15
+        specifier: ^3.23.8
+        version: 3.23.8
       zustand:
         specifier: ^5.0.7
         version: 5.0.7(@types/react@19.1.9)(react@19.1.0)
@@ -3092,8 +3092,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@4.0.15:
-    resolution: {integrity: sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==}
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
   zustand@5.0.7:
     resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
@@ -6230,7 +6230,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@4.0.15: {}
+  zod@3.23.8: {}
 
   zustand@5.0.7(@types/react@19.1.9)(react@19.1.0):
     optionalDependencies:

--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { POST } from './route'
+import { getServerAuthSession } from '@/lib/auth'
+import { redis } from '@/lib/redis'
+
+const sessionMock = vi.mocked(getServerAuthSession)
+
+describe('matchmaking API', () => {
+  it('enqueues user when no opponent is available', async () => {
+    sessionMock.mockResolvedValueOnce({ user: { id: 'u1' } })
+    vi.mocked(redis.lpop).mockResolvedValueOnce(null)
+
+    const res = await POST(jsonRequest({}))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ queued: true })
+    expect(redis.rpush).toHaveBeenCalledWith('matchmaking:queue', 'u1')
+  })
+
+  it('returns match details when opponent found', async () => {
+    sessionMock.mockResolvedValueOnce({ user: { id: 'u2' } })
+    vi.mocked(redis.lpop).mockResolvedValueOnce('u1')
+
+    const res = await POST(jsonRequest({}))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toMatchObject({
+      p1: 'u1',
+      p2: 'u2',
+      matchId: expect.any(String),
+    })
+    expect(redis.set).toHaveBeenCalled()
+  })
+
+  it('returns 401 for unauthenticated users', async () => {
+    sessionMock.mockResolvedValueOnce(null)
+
+    const res = await POST(jsonRequest({}))
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthenticated' })
+    expect(redis.lpop).not.toHaveBeenCalled()
+  })
+
+  it('handles queue errors', async () => {
+    sessionMock.mockResolvedValueOnce({ user: { id: 'u1' } })
+    vi.mocked(redis.lpop).mockRejectedValueOnce(new Error('boom'))
+
+    const res = await POST(jsonRequest({}))
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'queue error' })
+  })
+})

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,8 +1,38 @@
 import { NextResponse } from 'next/server'
+import { randomUUID } from 'node:crypto'
 
 import { getServerAuthSession } from '@/lib/auth'
 import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+const QUEUE_KEY = 'matchmaking:queue'
+
+// A simple matchmaking endpoint. When a user posts to this endpoint we try to
+// pull another waiting user from a Redis queue. If an opponent is found a match
+// is created and returned to the caller. Otherwise the user is enqueued and the
+// caller is informed that they're waiting for an opponent.
+export async function POST(_req: Request) {
+  const session = await getServerAuthSession()
+  const userId = session?.user?.id
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  try {
+    const opponentId = await redis.lpop<string>(QUEUE_KEY)
+    if (opponentId && opponentId !== userId) {
+      const matchId = randomUUID()
+      await redis.set(
+        `match:${matchId}`,
+        JSON.stringify({ p1: opponentId, p2: userId }),
+      )
+      return NextResponse.json({ matchId, p1: opponentId, p2: userId })
+    }
+
+    await redis.rpush(QUEUE_KEY, userId)
+    return NextResponse.json({ queued: true })
+  } catch {
+    return NextResponse.json({ error: 'queue error' }, { status: 500 })
+  }
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,25 @@
 import '@testing-library/jest-dom'
 import { afterEach, vi } from 'vitest'
 
+// Mock auth and redis modules used by API routes to avoid touching real
+// services during unit tests. Individual tests can adjust the behaviour of
+// these mocks as needed.
+vi.mock('@/lib/auth', () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue({ user: { id: 'user-id' } }),
+}))
+
+vi.mock('@/lib/redis', () => {
+  const redis = {
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(null),
+    lpop: vi.fn(),
+    rpush: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  }
+  return { redis }
+})
+
 afterEach(() => {
   vi.clearAllMocks()
 })


### PR DESCRIPTION
## Summary
- add edge runtime matchmaking route
- mock auth/redis and add comprehensive matchmaking API tests
- pin zod to v3 for compatibility

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8e0688a08328a98ad606366d02d6