### PR TITLE
feat: add matchmaking POST handler

### DIFF
--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('../../../lib/redis', () => ({
+  redis: {
+    lpop: vi.fn(),
+    rpush: vi.fn(),
+  },
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  getServerAuthSession: vi.fn(),
+}))
+
+import { redis } from '../../../lib/redis'
+import { getServerAuthSession } from '../../../lib/auth'
+
+const redisMock = vi.mocked(redis)
+const authMock = vi.mocked(getServerAuthSession)
+
+describe('matchmaking API', () => {
+  it('queues user when no opponent', async () => {
+    authMock.mockResolvedValue({ user: { id: 'u1' } } as any)
+    redisMock.lpop.mockResolvedValue(null)
+
+    const res = await POST()
+    expect(res.status).toBe(202)
+    expect(await res.json()).toEqual({ queued: true })
+    expect(redisMock.rpush).toHaveBeenCalledWith('matchmaking_queue', 'u1')
+  })
+
+  it('matches with waiting user', async () => {
+    authMock.mockResolvedValue({ user: { id: 'u2' } } as any)
+    redisMock.lpop.mockResolvedValue('u1')
+
+    const res = await POST()
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.players).toEqual(['u1', 'u2'])
+    expect(typeof json.id).toBe('string')
+    expect(redisMock.rpush).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    authMock.mockResolvedValue(null)
+
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthorized' })
+  })
+
+  it('returns 500 on redis error', async () => {
+    authMock.mockResolvedValue({ user: { id: 'u1' } } as any)
+    redisMock.lpop.mockRejectedValue(new Error('oops'))
+
+    const res = await POST()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'queue_failed' })
+  })
+})

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -5,4 +5,29 @@ import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+const QUEUE_KEY = 'matchmaking_queue'
+
+export async function POST() {
+  const session = await getServerAuthSession()
+  const userId = session?.user?.id
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const opponentId = await redis.lpop<string>(QUEUE_KEY)
+
+    if (opponentId && opponentId !== userId) {
+      const match = {
+        id: crypto.randomUUID(),
+        players: [opponentId, userId],
+      }
+      return NextResponse.json(match)
+    }
+
+    await redis.rpush(QUEUE_KEY, userId)
+    return NextResponse.json({ queued: true }, { status: 202 })
+  } catch (err) {
+    return NextResponse.json({ error: 'queue_failed' }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary
- implement Redis-backed matchmaking POST handler with authenticated users
- handle unauthorized requests and queue errors
- add unit tests for matchmaking queue logic

## Testing
- `pnpm test` *(fails: Cannot find module 'nodemailer'; Failed to parse URL from /pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e059dc08328bc5ac0af612daf1a