### PR TITLE
feat: add Phaser main scene and responsive game canvas

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1,30 +1,58 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import Phaser from 'phaser'
+import type PhaserType from 'phaser'
+import { useSettings } from '@/store/settings'
 
 export function GameCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const gameRef = useRef<PhaserType.Game>()
+  const muted = useSettings((s) => s.muted)
 
   useEffect(() => {
     if (!containerRef.current) return
 
-    const game = new Phaser.Game({
-      type: Phaser.AUTO,
-      parent: containerRef.current,
-      width: 800,
-      height: 600,
-      scene: {
-        preload() {},
-        create() {},
-        update() {},
-      },
-    })
+    let resize: () => void
+
+    const init = async () => {
+      const Phaser = (await import('phaser')).default
+      const { default: MainScene } = await import('@/game/MainScene')
+
+      const { clientWidth: width, clientHeight: height } = containerRef.current!
+      gameRef.current = new Phaser.Game({
+        type: Phaser.AUTO,
+        parent: containerRef.current!,
+        width,
+        height,
+        scene: MainScene,
+      })
+
+      gameRef.current.sound.mute = muted
+
+      resize = () => {
+        if (!containerRef.current || !gameRef.current) return
+        const { clientWidth: w, clientHeight: h } = containerRef.current
+        gameRef.current.scale.resize(w, h)
+      }
+
+      window.addEventListener('resize', resize)
+    }
+
+    init()
 
     return () => {
-      game.destroy(true)
+      window.removeEventListener('resize', resize)
+      gameRef.current?.destroy(true)
+      gameRef.current = undefined
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return <div ref={containerRef} />
+  useEffect(() => {
+    if (gameRef.current) {
+      gameRef.current.sound.mute = muted
+    }
+  }, [muted])
+
+  return <div ref={containerRef} className="w-full h-full" />
 }

--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -1,0 +1,32 @@
+import Phaser from 'phaser'
+
+export default class MainScene extends Phaser.Scene {
+  private ball!: Phaser.GameObjects.Arc
+  private velocity = new Phaser.Math.Vector2(200, 200)
+
+  constructor() {
+    super('MainScene')
+  }
+
+  preload() {
+    // Preload assets here if needed
+  }
+
+  create() {
+    const { width, height } = this.scale
+    this.ball = this.add.circle(width / 2, height / 2, 10, 0xffffff)
+  }
+
+  update(_time: number, delta: number) {
+    const dt = delta / 1000
+    this.ball.x += this.velocity.x * dt
+    this.ball.y += this.velocity.y * dt
+
+    if (this.ball.x <= 0 || this.ball.x >= this.scale.width) {
+      this.velocity.x *= -1
+    }
+    if (this.ball.y <= 0 || this.ball.y >= this.scale.height) {
+      this.velocity.y *= -1
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define `MainScene` Phaser scene with simple bouncing ball
- make `GameCanvas` dynamically load Phaser, apply responsive resizing and audio mute settings

## Testing
- `pnpm lint` *(fails: Parsing error in src/app/api/matchmaking/route.ts)*
- `pnpm typecheck` *(fails: Declaration or statement expected in src/app/api/matchmaking/route.ts)*
- `pnpm test` *(fails: missing Redis config and nodemailer module)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e011fd88328b7e2f39e7afbe247