### PR TITLE
feat: standardize API error handling

### DIFF
--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    leaderboard: { findMany: vi.fn(async () => [{ elo: 100 }]) },
+  },
+}))
+
+import { GET } from './route'
+import { prisma } from '../../../lib/prisma'
+
+describe('leaderboard API', () => {
+  it('returns leaderboard', async () => {
+    const res = await GET()
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json).toEqual([{ elo: 100 }])
+  })
+
+  it('handles errors', async () => {
+    ;(prisma.leaderboard.findMany as any).mockRejectedValueOnce(
+      new Error('fail'),
+    )
+    const res = await GET()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ ok: false, error: 'server error' })
+  })
+})

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { error } from '@/utils/api'
 
 export async function GET() {
-  const data = await prisma.leaderboard.findMany({
-    take: 10,
-    orderBy: { elo: 'desc' },
-    include: { user: true },
-  })
-  return NextResponse.json(data)
+  try {
+    const data = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      include: { user: true },
+    })
+    return NextResponse.json(data)
+  } catch {
+    return error(500, 'server error')
+  }
 }

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { getServerAuthSession } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { error, parseBody } from '@/utils/api'
 
 const bodySchema = z.object({
   matchId: z.string(),
@@ -14,17 +15,18 @@ const bodySchema = z.object({
 export async function POST(req: Request) {
   const session = await getServerAuthSession()
   if (!session?.user) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    return error(401, 'unauthorized')
   }
-  const json = await req.json()
-  const parsed = bodySchema.safeParse(json)
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  const [body, bodyErr] = await parseBody(bodySchema, req)
+  if (bodyErr) return bodyErr
+  const { matchId, p1Score, p2Score, winnerId } = body!
+  try {
+    await prisma.match.update({
+      where: { id: matchId },
+      data: { p1Score, p2Score, winnerId, endedAt: new Date() },
+    })
+  } catch {
+    return error(500, 'server error')
   }
-  const { matchId, p1Score, p2Score, winnerId } = parsed.data
-  await prisma.match.update({
-    where: { id: matchId },
-    data: { p1Score, p2Score, winnerId, endedAt: new Date() },
-  })
   return NextResponse.json({ ok: true })
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import type { z } from 'zod'
+
+export function error(status: number, message: string) {
+  return NextResponse.json({ ok: false, error: message }, { status })
+}
+
+export async function parseBody<T>(
+  schema: z.Schema<T>,
+  req: Request,
+): Promise<[T | null, NextResponse | null]> {
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return [null, error(400, 'invalid')]
+  }
+  const parsed = schema.safeParse(json)
+  if (!parsed.success) {
+    return [null, error(400, 'invalid')]
+  }
+  return [parsed.data, null]
+}


### PR DESCRIPTION
## Summary
- add shared API helpers for parsing bodies and building error responses
- refactor score, telemetry, and leaderboard routes to use helpers
- expand unit tests to cover standardized failure responses

## Testing
- `pnpm test src/app/api/telemetry/route.test.ts src/app/api/score/route.test.ts src/app/api/leaderboard/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a8e004b988328a8f08f433d3ad7e3