### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,11 @@
 import posthog from 'posthog-js'
+import { env } from '@/lib/env'
 
 export function initAnalytics() {
   if (typeof window === 'undefined') return
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
   })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,20 +4,21 @@ import GithubProvider from 'next-auth/providers/github'
 import EmailProvider from 'next-auth/providers/email'
 
 import { prisma } from '@/lib/prisma'
+import { env } from '@/lib/env'
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
+      server: env.EMAIL_SERVER,
+      from: env.EMAIL_FROM,
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
     }),
   ],
-  secret: process.env.AUTH_SECRET,
+  secret: env.AUTH_SECRET,
 }
 
 export const getServerAuthSession = () => getServerSession(authOptions)

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+export const envSchema = z.object({
+  NODE_ENV: z
+    .enum(['development', 'test', 'production'])
+    .default('development'),
+  EMAIL_SERVER: z.string().min(1),
+  EMAIL_FROM: z.string().email(),
+  GITHUB_ID: z.string().min(1),
+  GITHUB_SECRET: z.string().min(1),
+  AUTH_SECRET: z.string().min(1),
+  UPSTASH_REDIS_URL: z.string().url(),
+  UPSTASH_REDIS_TOKEN: z.string().min(1),
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
+})
+
+const _env = envSchema.safeParse(process.env)
+
+if (!_env.success) {
+  console.error(
+    'Invalid environment variables:\n',
+    _env.error.flatten().fieldErrors,
+  )
+  throw new Error('Invalid environment variables')
+}
+
+export const env = _env.data

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client'
+import { env } from '@/lib/env'
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
 
 export const prisma =
   globalForPrisma.prisma || new PrismaClient({ log: ['error', 'warn'] })
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,7 @@
 import { Redis } from '@upstash/redis'
+import { env } from '@/lib/env'
 
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_URL!,
-  token: process.env.UPSTASH_REDIS_TOKEN!,
+  url: env.UPSTASH_REDIS_URL,
+  token: env.UPSTASH_REDIS_TOKEN,
 })


### PR DESCRIPTION
## Summary
- add zod-based env schema and typed `env` export
- use shared env object across auth, redis, analytics, and prisma modules

## Testing
- `pnpm lint` (fails: Parsing error: Declaration or statement expected)
- `pnpm test` (fails: No test suite found; Cannot find module 'nodemailer'; fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_689a8dffddd483288627232114dde737