### PR TITLE
feat: add matchmaking queue

### DIFF
--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('../../../lib/redis', () => ({
+  redis: {
+    lpush: vi.fn(),
+    rpop: vi.fn(),
+  },
+}))
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    match: { create: vi.fn() },
+  },
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  getServerAuthSession: vi.fn(),
+}))
+
+import { redis } from '../../../lib/redis'
+import { prisma } from '../../../lib/prisma'
+import { getServerAuthSession } from '../../../lib/auth'
+
+describe('matchmaking API', () => {
+  it('queues user when no opponent is available', async () => {
+    getServerAuthSession.mockResolvedValue({ user: { id: 'u1' } })
+    redis.rpop.mockResolvedValue(null)
+
+    const res = await POST(new Request('http://localhost'))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ queued: true })
+    expect(redis.lpush).toHaveBeenCalledWith('matchmaking:queue', 'u1')
+  })
+
+  it('matches user with waiting opponent', async () => {
+    getServerAuthSession.mockResolvedValue({ user: { id: 'u2' } })
+    redis.rpop.mockResolvedValue('u1')
+    prisma.match.create.mockResolvedValue({ id: 'm1' })
+
+    const res = await POST(new Request('http://localhost'))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({ matchId: 'm1' })
+    expect(prisma.match.create).toHaveBeenCalledWith({
+      data: {
+        mode: 'matchmaking',
+        p1Id: 'u1',
+        p2Id: 'u2',
+        p1Score: 0,
+        p2Score: 0,
+      },
+    })
+  })
+})

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,8 +1,40 @@
 import { NextResponse } from 'next/server'
 
 import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
 import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+const QUEUE_KEY = 'matchmaking:queue'
+
+export async function POST() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const userId = session.user.id
+
+  const opponentId = await redis.rpop<string>(QUEUE_KEY)
+
+  if (opponentId && opponentId !== userId) {
+    const match = await prisma.match.create({
+      data: {
+        mode: 'matchmaking',
+        p1Id: opponentId,
+        p2Id: userId,
+        p1Score: 0,
+        p2Score: 0,
+      },
+    })
+    return NextResponse.json({ matchId: match.id })
+  }
+
+  if (opponentId) {
+    await redis.lpush(QUEUE_KEY, opponentId)
+  }
+
+  await redis.lpush(QUEUE_KEY, userId)
+  return NextResponse.json({ queued: true })
 }


### PR DESCRIPTION
## Summary
- add matchmaking POST handler using Redis queue and Prisma match creation
- test matchmaking flow for queueing and pairing

## Testing
- `pnpm test` *(fails: Cannot find module 'nodemailer'; Upstash Redis URL/token undefined)*
- `npx vitest run src/app/api/matchmaking/route.test.ts --reporter=verbose`


------
https://chatgpt.com/codex/tasks/task_e_689a8dfedb548328824b6267aeeed298