### PR TITLE
Add telemetry GET tests and refine logging

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -40,7 +40,9 @@ async function main() {
 
 main()
   .catch((e) => {
-    console.error(e)
+    console.warn('seed failed', {
+      error: e instanceof Error ? e.message : String(e),
+    })
     process.exit(1)
   })
   .finally(async () => {

--- a/src/app/api/telemetry/route.get.test.ts
+++ b/src/app/api/telemetry/route.get.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    telemetry: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('../../../lib/redis', () => ({
+  redis: {
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn(),
+  },
+}))
+
+import { GET } from './route'
+import { prisma } from '../../../lib/prisma'
+
+describe('telemetry GET API', () => {
+  it('filters by eventType and since', async () => {
+    const mockData = [
+      {
+        id: 1,
+        eventType: 'start',
+        payload: { foo: 'bar' },
+        userId: 'u1',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+    ]
+    prisma.telemetry.findMany.mockResolvedValue(mockData)
+
+    const res = await GET(
+      new Request(
+        'http://localhost/api/telemetry?eventType=start&since=2023-12-31',
+      ),
+    )
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual(
+      mockData.map((d) => ({ ...d, createdAt: d.createdAt.toISOString() })),
+    )
+    expect(prisma.telemetry.findMany).toHaveBeenCalledWith({
+      where: {
+        eventType: 'start',
+        createdAt: { gte: new Date('2023-12-31') },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    })
+  })
+
+  it('returns 400 on invalid since', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/telemetry?since=not-a-date'),
+    )
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'invalid since' })
+    expect(prisma.telemetry.findMany).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest'
-import { POST } from './route'
 
 vi.mock('../../../lib/prisma', () => ({
   prisma: {
@@ -7,6 +6,14 @@ vi.mock('../../../lib/prisma', () => ({
   },
 }))
 
+vi.mock('../../../lib/redis', () => ({
+  redis: {
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn(),
+  },
+}))
+
+import { POST } from './route'
 import { prisma } from '../../../lib/prisma'
 
 describe('telemetry API', () => {

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -16,6 +16,9 @@ const schema = z.object({
   userId: z.string().optional(),
 })
 
+const RATE_LIMIT_WINDOW_SECONDS = 60
+const RATE_LIMIT_MAX_REQUESTS = 60
+
 export async function POST(req: Request) {
   const ip =
     req.headers.get('x-forwarded-for') ??
@@ -24,9 +27,9 @@ export async function POST(req: Request) {
   const key = `telemetry:ip:${ip}`
   const count = await redis.incr(key)
   if (count === 1) {
-    await redis.expire(key, 60)
+    await redis.expire(key, RATE_LIMIT_WINDOW_SECONDS)
   }
-  if (count > 60) {
+  if (count > RATE_LIMIT_MAX_REQUESTS) {
     return NextResponse.json({ error: 'rate limited' }, { status: 429 })
   }
   const json = await req.json()
@@ -37,7 +40,9 @@ export async function POST(req: Request) {
   try {
     await prisma.telemetry.create({ data: parsed.data })
   } catch (err) {
-    console.error('telemetry insert failed', err)
+    console.warn('telemetry insert failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
     return NextResponse.json({ error: 'server error' }, { status: 500 })
   }
   return NextResponse.json({ ok: true })
@@ -52,9 +57,10 @@ export async function GET(req: Request) {
   if (eventType) where.eventType = eventType
   if (since) {
     const date = new Date(since)
-    if (!isNaN(date.getTime())) {
-      where.createdAt = { gte: date }
+    if (isNaN(date.getTime())) {
+      return NextResponse.json({ error: 'invalid since' }, { status: 400 })
     }
+    where.createdAt = { gte: date }
   }
 
   const data = await prisma.telemetry.findMany({


### PR DESCRIPTION
## Summary
- replace telemetry console errors with sanitized console.warn logging
- factor rate-limiting constants into named variables
- add GET telemetry tests covering eventType and since query params
- return 400 for invalid since values
- sanitize seed script logging

## Testing
- `pnpm test src/app/api/telemetry/route.test.ts src/app/api/telemetry/route.get.test.ts` *(fails: Cannot read properties of undefined (reading '_zod'))*
- `pnpm test src/app/api/telemetry/route.get.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a8dfa027c83289e2d624b270dcc2b