### PR TITLE
Implement Redis-backed matchmaking API route

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -5,4 +5,37 @@ import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+const QUEUE_KEY = 'matchmaking_queue'
+
+export async function POST() {
+  const session = await getServerAuthSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const userId = session.user.id
+
+  try {
+    const opponentId = await redis.lpop<string>(QUEUE_KEY)
+
+    if (!opponentId || opponentId === userId) {
+      await redis.rpush(QUEUE_KEY, userId)
+      return NextResponse.json({ status: 'waiting' })
+    }
+
+    const matchId = crypto.randomUUID()
+    await redis.hset(`match:${matchId}`, { p1Id: opponentId, p2Id: userId })
+
+    return NextResponse.json({
+      match: {
+        id: matchId,
+        p1Id: opponentId,
+        p2Id: userId,
+      },
+    })
+  } catch (e) {
+    return NextResponse.json({ error: 'server_error' }, { status: 500 })
+  }
 }
+
+export const GET = POST


### PR DESCRIPTION
## Summary
- implement matchmaking POST API that authenticates users and pairs queued players via Redis
- allow GET to mirror POST

## Testing
- `pnpm test` *(fails: No test suite found in file src/app/api/matchmaking/route.test.ts; Cannot find module 'nodemailer'; TypeError: Failed to parse URL from /pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_689a8df8facc832897a9cc21e14ebb69