### PR TITLE
feat(prisma): index leaderboard elo

### DIFF
--- a/prisma/migrations/20250812000000_add_leaderboard_elo_index/migration.sql
+++ b/prisma/migrations/20250812000000_add_leaderboard_elo_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Leaderboard_elo_idx" ON "Leaderboard"("elo");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Leaderboard {
   losses    Int    @default(0)
   streak    Int    @default(0)
   updatedAt DateTime @updatedAt
+  @@index([elo])
 }
 
 model Telemetry {


### PR DESCRIPTION
## Summary
- add index on `Leaderboard.elo`
- include migration for new index

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma migrate dev --name add-elo-index` *(fails: 403 Forbidden)*
- `psql postgresql://postgres:postgres@localhost:5432/pong -c 'EXPLAIN ANALYZE SELECT * FROM "Leaderboard" WHERE "elo" > 1000;'`
- `psql postgresql://postgres:postgres@localhost:5432/pong -c 'SELECT userId, elo FROM "Leaderboard" ORDER BY "elo" DESC;'`
- `pnpm test` *(fails: No test suite found; Cannot find module 'nodemailer'; Invalid URL /pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_689a8df193408328b809702284504aa3