### PR TITLE
feat: validate environment variables

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,12 @@
 import posthog from 'posthog-js'
 
+import { env } from '@/lib/env'
+
 export function initAnalytics() {
   if (typeof window === 'undefined') return
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
   posthog.init(key, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
   })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,20 +4,21 @@ import GithubProvider from 'next-auth/providers/github'
 import EmailProvider from 'next-auth/providers/email'
 
 import { prisma } from '@/lib/prisma'
+import { env } from '@/lib/env'
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     EmailProvider({
-      server: process.env.EMAIL_SERVER!,
-      from: process.env.EMAIL_FROM!,
+      server: env.EMAIL_SERVER,
+      from: env.EMAIL_FROM,
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
     }),
   ],
-  secret: process.env.AUTH_SECRET,
+  secret: env.AUTH_SECRET,
 }
 
 export const getServerAuthSession = () => getServerSession(authOptions)

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const baseEnv = {
+  EMAIL_SERVER: 'smtp://localhost',
+  EMAIL_FROM: 'noreply@example.com',
+  GITHUB_ID: 'id',
+  GITHUB_SECRET: 'secret',
+  AUTH_SECRET: 'auth',
+  UPSTASH_REDIS_URL: 'https://example.com',
+  UPSTASH_REDIS_TOKEN: 'token',
+}
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  process.env = { ...originalEnv, ...baseEnv }
+  vi.resetModules()
+})
+
+describe('env', () => {
+  it('throws on missing environment variables', async () => {
+    delete process.env.AUTH_SECRET
+    await expect(import('./env')).rejects.toThrow(/AUTH_SECRET/)
+  })
+
+  it('throws on invalid environment variables', async () => {
+    process.env.UPSTASH_REDIS_URL = 'not-a-url'
+    await expect(import('./env')).rejects.toThrow(/UPSTASH_REDIS_URL/)
+  })
+})

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  EMAIL_SERVER: z.string(),
+  EMAIL_FROM: z.string(),
+  GITHUB_ID: z.string(),
+  GITHUB_SECRET: z.string(),
+  AUTH_SECRET: z.string(),
+  UPSTASH_REDIS_URL: z.string().url(),
+  UPSTASH_REDIS_TOKEN: z.string(),
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
+})
+
+export const env = envSchema.parse(process.env)

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,8 @@
 import { Redis } from '@upstash/redis'
 
+import { env } from '@/lib/env'
+
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_URL!,
-  token: process.env.UPSTASH_REDIS_TOKEN!,
+  url: env.UPSTASH_REDIS_URL,
+  token: env.UPSTASH_REDIS_TOKEN,
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,15 @@
 import '@testing-library/jest-dom'
 import { afterEach, vi } from 'vitest'
 
+process.env.EMAIL_SERVER = process.env.EMAIL_SERVER ?? 'smtp://localhost'
+process.env.EMAIL_FROM = process.env.EMAIL_FROM ?? 'noreply@example.com'
+process.env.GITHUB_ID = process.env.GITHUB_ID ?? 'id'
+process.env.GITHUB_SECRET = process.env.GITHUB_SECRET ?? 'secret'
+process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'auth'
+process.env.UPSTASH_REDIS_URL =
+  process.env.UPSTASH_REDIS_URL ?? 'https://example.com'
+process.env.UPSTASH_REDIS_TOKEN = process.env.UPSTASH_REDIS_TOKEN ?? 'token'
+
 afterEach(() => {
   vi.clearAllMocks()
 })


### PR DESCRIPTION
## Summary
- add `env` schema using zod
- load auth, redis, analytics configuration from validated `env`
- test that missing or invalid environment variables throw errors

## Testing
- `pnpm test src/lib/env.test.ts`
- `pnpm test` *(fails: No test suite found in matchmaking/route.test.ts; Cannot find module 'nodemailer'; fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a8deff82083288cb6bd5c32d21980