### PR TITLE
feat: add Phaser scene and responsive canvas

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -2,29 +2,63 @@
 
 import { useEffect, useRef } from 'react'
 import Phaser from 'phaser'
+import { MainScene } from '@/game/Scenes/MainScene'
 
-export function GameCanvas() {
+interface GameCanvasProps {
+  width?: number
+  height?: number
+}
+
+export function GameCanvas({ width, height }: GameCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const gameRef = useRef<Phaser.Game | null>(null)
 
   useEffect(() => {
-    if (!containerRef.current) return
+    const container = containerRef.current
+    if (!container) return
+
+    const getSize = () => {
+      if (width && height) return { width, height }
+      const rect = container.getBoundingClientRect()
+      return {
+        width: rect.width || 800,
+        height: rect.height || 600,
+      }
+    }
+
+    const { width: w, height: h } = getSize()
 
     const game = new Phaser.Game({
       type: Phaser.AUTO,
-      parent: containerRef.current,
-      width: 800,
-      height: 600,
-      scene: {
-        preload() {},
-        create() {},
-        update() {},
-      },
+      parent: container,
+      width: w,
+      height: h,
+      scene: MainScene,
     })
+    gameRef.current = game
+
+    const handleResize = () => {
+      if (!gameRef.current) return
+      const { width: newWidth, height: newHeight } = getSize()
+      gameRef.current.scale.resize(newWidth, newHeight)
+    }
+
+    window.addEventListener('resize', handleResize)
 
     return () => {
-      game.destroy(true)
+      window.removeEventListener('resize', handleResize)
+      gameRef.current?.destroy(true)
+      gameRef.current = null
     }
-  }, [])
+  }, [width, height])
 
-  return <div ref={containerRef} />
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: width ? `${width}px` : '100%',
+        height: height ? `${height}px` : '100%',
+      }}
+    />
+  )
 }

--- a/src/game/Scenes/MainScene.ts
+++ b/src/game/Scenes/MainScene.ts
@@ -1,0 +1,13 @@
+import Phaser from 'phaser'
+
+export class MainScene extends Phaser.Scene {
+  constructor() {
+    super('MainScene')
+  }
+
+  preload() {}
+
+  create() {}
+
+  update() {}
+}


### PR DESCRIPTION
## Summary
- add Phaser MainScene class
- resize-aware GameCanvas component

## Testing
- `pnpm lint` *(fails: Parsing error: Declaration or statement expected.)*
- `pnpm test` *(fails: No test suite found in file /workspace/pong/src/app/api/matchmaking/route.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a8def7a548328b61c48ed03d538fe