### PR TITLE
feat: guard analytics init

### DIFF
--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -1,11 +1,16 @@
 'use client'
 
 import { useEffect } from 'react'
-import { initAnalytics } from '../lib/analytics'
+import { initAnalytics } from '@/lib/analytics'
+
+let initialized = false
 
 export function AnalyticsProvider() {
   useEffect(() => {
-    initAnalytics()
+    if (!initialized && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+      initAnalytics()
+      initialized = true
+    }
   }, [])
   return null
 }


### PR DESCRIPTION
## Summary
- update analytics import path
- avoid reinitializing PostHog analytics

## Testing
- `pnpm lint` (fails: Parsing error: Declaration or statement expected)
- `pnpm test` (fails: Cannot find module 'nodemailer' etc.)

------
https://chatgpt.com/codex/tasks/task_e_689a8deee8b88328b030468eecfb3394