### PR TITLE
Implement matchmaking POST endpoint

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -5,4 +5,30 @@ import { getServerAuthSession } from '@/lib/auth'
 import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
+export async function POST() {
+  const session = await getServerAuthSession()
+  const userId = session?.user?.id
 
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  try {
+    const opponentId = await redis.lpop<string>('matchmaking:queue')
+
+    if (!opponentId) {
+      await redis.rpush('matchmaking:queue', userId)
+      return NextResponse.json({ queued: true })
+    }
+
+    const matchId = randomUUID()
+    await redis.set(
+      `matchmaking:match:${matchId}`,
+      JSON.stringify({ p1: opponentId, p2: userId }),
+    )
+
+    return NextResponse.json({ p1: opponentId, p2: userId, matchId })
+  } catch {
+    return NextResponse.json({ error: 'queue error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add POST matchmaking API to pair users using Redis
- queue users when no opponent available and create match pairings

## Testing
- `pnpm test src/app/api/matchmaking/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ad3f9d2188328986a324b73c201a3