### PR TITLE
Queue leaderboard recalculation

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -6,3 +6,29 @@ import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+const QUEUE_KEY = 'matchmaking:queue'
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  const userId = session.user.id
+  try {
+    const opponent = await redis.lpop(QUEUE_KEY)
+    if (!opponent) {
+      await redis.rpush(QUEUE_KEY, userId)
+      return NextResponse.json({ queued: true })
+    }
+
+    const matchId = randomUUID()
+    await redis.set(
+      `match:${matchId}`,
+      JSON.stringify({ p1: opponent, p2: userId }),
+    )
+    return NextResponse.json({ p1: opponent, p2: userId, matchId })
+  } catch (err) {
+    return NextResponse.json({ error: 'queue error' }, { status: 500 })
+  }
+}

--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 
-
 vi.mock('../../../lib/prisma', () => ({
   prisma: {
     telemetry: {
@@ -17,6 +16,10 @@ vi.mock('../../../lib/redis', () => ({
   },
 }))
 
+import { GET, POST } from './route'
+import { prisma } from '../../../lib/prisma'
+import { redis } from '../../../lib/redis'
+import { z } from 'zod'
 
 describe('telemetry API', () => {
   it('fails payload validation for oversized payload', () => {

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  triggerLeaderboardRecalculation,
+  LEADERBOARD_RECALC_CHANNEL,
+} from './leaderboard'
+import { redis } from '@/lib/redis'
+
+describe('triggerLeaderboardRecalculation', () => {
+  it('enqueues a leaderboard recalculation job', async () => {
+    await triggerLeaderboardRecalculation()
+    expect(redis.rpush).toHaveBeenCalledWith(
+      LEADERBOARD_RECALC_CHANNEL,
+      JSON.stringify({}),
+    )
+  })
+})

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,3 +1,15 @@
+import { redis } from '@/lib/redis'
+
+/** Redis list used to queue leaderboard recomputation jobs. */
+export const LEADERBOARD_RECALC_CHANNEL = 'leaderboard:recalc'
+
+/**
+ * Enqueue a job for leaderboard recalculation.
+ *
+ * The payload is intentionally minimal – a JSON encoded empty object – as the
+ * worker that consumes this queue only needs a signal to perform a refresh.
+ */
 export async function triggerLeaderboardRecalculation() {
-  // placeholder for job queueing to recalc leaderboard
+  const payload = JSON.stringify({})
+  await redis.rpush(LEADERBOARD_RECALC_CHANNEL, payload)
 }


### PR DESCRIPTION
## Summary
- enqueue leaderboard recalculation requests on a Redis list
- cover leaderboard queuing with unit test
- add matchmaking POST handler and fix telemetry tests for passing vitest suite

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad3faef748328aae0018c07253771