### PR TITLE
Initialize Phaser game in GameCanvas

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1,15 +1,40 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import type Phaser from 'phaser'
 
+import MainScene from '@/game/MainScene'
+import { useSettings } from '@/store/settings'
 
 export function GameCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
-  const gameRef = useRef<PhaserType.Game>()
+  const gameRef = useRef<Phaser.Game>()
   const muted = useSettings((s) => s.muted)
 
   useEffect(() => {
     if (!containerRef.current) return
+
+    let destroyed = false
+
+    import('phaser').then(({ default: Phaser }) => {
+      if (destroyed || !containerRef.current) return
+
+      const game = new Phaser.Game({
+        type: Phaser.AUTO,
+        parent: containerRef.current,
+        width: containerRef.current.clientWidth,
+        height: containerRef.current.clientHeight,
+        scene: MainScene,
+      })
+
+      game.sound.mute = muted
+      gameRef.current = game
+    })
+
+    return () => {
+      destroyed = true
+      gameRef.current?.destroy(true)
+      gameRef.current = undefined
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
## Summary
- import Phaser types and settings hook
- dynamically load Phaser and start MainScene, cleaning up on unmount
- sync game audio mute with settings state

## Testing
- `pnpm lint` *(fails: Unexpected token `}` in next.config.ts)*
- `pnpm exec eslint src/components/GameCanvas.tsx`
- `pnpm test` *(fails: POST is not a function, ReferenceError: z/prisma/redis not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ad40ba7f08328ae3e147fc15ed924