### PR TITLE
feat: implement matchmaking POST endpoint

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -6,3 +6,25 @@ import { redis } from '@/lib/redis'
 
 export const runtime = 'edge'
 
+export async function POST(_req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const userId = session.user.id
+  try {
+    const opponent = await redis.lpop<string>('matchmaking:queue')
+    if (!opponent) {
+      await redis.rpush('matchmaking:queue', userId)
+      return NextResponse.json({ queued: true })
+    }
+    const matchId = randomUUID()
+    await redis.set(
+      `match:${matchId}`,
+      JSON.stringify({ p1: opponent, p2: userId }),
+    )
+    return NextResponse.json({ p1: opponent, p2: userId, matchId })
+  } catch (err) {
+    return NextResponse.json({ error: 'queue error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add POST handler for matchmaking API to pair players or queue them
- persist match data in redis and handle auth and error responses

## Testing
- `pnpm test src/app/api/matchmaking/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ad40cdcd4832895bf470fb42f3343