### PR TITLE
refactor telemetry route tests

### DIFF
--- a/src/app/api/telemetry/route.test.ts
+++ b/src/app/api/telemetry/route.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 
-
 vi.mock('../../../lib/prisma', () => ({
   prisma: {
     telemetry: {
@@ -17,28 +16,16 @@ vi.mock('../../../lib/redis', () => ({
   },
 }))
 
+import { z } from 'zod'
+import { GET, POST, schema } from './route'
+import { prisma } from '../../../lib/prisma'
+import { redis } from '../../../lib/redis'
 
 describe('telemetry API', () => {
   it('fails payload validation for oversized payload', () => {
     const payload = Object.fromEntries(
       Array.from({ length: 51 }, (_, i) => [`k${i}`, i]),
     )
-    const schema = z.object({
-      eventType: z.string(),
-      payload: z
-        .custom<Record<string, unknown>>(
-          (val) =>
-            typeof val === 'object' && val !== null && !Array.isArray(val),
-        )
-        .refine((val) => Object.keys(val).length <= 50, {
-          message: 'payload too large',
-        })
-        .refine((val) => JSON.stringify(val).length <= 1000, {
-          message: 'payload too large',
-        }),
-      userId: z.string().optional(),
-    })
-
     const result = schema.safeParse({ eventType: 'start', payload })
     expect(result.success).toBe(false)
   })

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -6,7 +6,7 @@ import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
 const { z } = require('zod')
 
-const schema = z.object({
+export const schema = z.object({
   eventType: z.string(),
   payload: z
     .custom<Record<string, unknown>>(


### PR DESCRIPTION
## Summary
- export telemetry schema from API route for reuse
- refactor telemetry route tests to import GET/POST handlers and shared schema

## Testing
- `pnpm test src/app/api/telemetry/route.test.ts src/app/api/telemetry/route.get.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ad40edd14832882d940bc21903e8a