### PR TITLE
docs: remove stray character from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ pnpm dev
 
 Copy `.env.example` to `.env.local` and fill in secrets.
 
-<
 ## Architecture Overview
 
 ```mermaid


### PR DESCRIPTION
## Summary
- remove stray `<` from README

## Testing
- `pnpm lint` *(fails: Unexpected token `}` in next.config.ts)*
- `npx prettier README.md --check`


------
https://chatgpt.com/codex/tasks/task_e_689ad41662d48328ab816c8404e74bb2