### PR TITLE
Add auth header with NextAuth buttons and tests

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-
-  },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from 'next/script'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { AnalyticsProvider } from '../components/AnalyticsProvider'
+import { AuthButtons } from '../components/AuthButtons'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getLocale, getTranslations } from 'next-intl/server'
 
@@ -39,6 +40,9 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AnalyticsProvider />
+          <header className="p-4">
+            <AuthButtons />
+          </header>
           {children}
         </NextIntlClientProvider>
         <Script id="sw" strategy="afterInteractive">

--- a/src/components/AuthButtons.test.tsx
+++ b/src/components/AuthButtons.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { AuthButtons } from './AuthButtons'
+import { signIn, signOut, useSession } from 'next-auth/react'
+
+vi.mock('next-auth/react', () => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+const mockUseSession = vi.mocked(useSession)
+const mockSignIn = vi.mocked(signIn)
+const mockSignOut = vi.mocked(signOut)
+
+describe('AuthButtons', () => {
+  it('renders sign in button when unauthenticated and calls signIn on click', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' })
+    render(<AuthButtons />)
+    const button = screen.getByRole('button', { name: /sign in/i })
+    fireEvent.click(button)
+    expect(mockSignIn).toHaveBeenCalled()
+  })
+
+  it('renders sign out and session info when authenticated', () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { name: 'Alice', email: 'alice@example.com' } },
+      status: 'authenticated',
+    })
+    render(<AuthButtons />)
+    expect(screen.getByText(/alice@example.com/i)).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: /sign out/i })
+    fireEvent.click(button)
+    expect(mockSignOut).toHaveBeenCalled()
+  })
+})

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import React from 'react'
+import { signIn, signOut, useSession } from 'next-auth/react'
+
+export function AuthButtons() {
+  const { data: session } = useSession()
+
+  if (session?.user) {
+    const userLabel = session.user.email ?? session.user.name ?? 'User'
+    return (
+      <div>
+        <span>Signed in as {userLabel}</span>
+        <button onClick={() => signOut()}>Sign out</button>
+      </div>
+    )
+  }
+
+  return <button onClick={() => signIn()}>Sign in</button>
+}
+
+export default AuthButtons


### PR DESCRIPTION
## Summary
- add `AuthButtons` client component with NextAuth `signIn`/`signOut`
- render auth header in layout with session info
- test sign in/out flows via `next-auth/react` mocks
- fix malformed `next.config.ts`

## Testing
- `pnpm exec eslint src/components/AuthButtons.tsx src/app/layout.tsx src/components/AuthButtons.test.tsx`
- `pnpm typecheck` *(fails: GameCanvas.tsx: ',' expected)*
- `pnpm test src/components/AuthButtons.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ad41c29d88328a6b09847fd10ad5a