### PR TITLE
Add leaderboard page and test

### DIFF
--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+test('leaderboard page lists players', async ({ page }) => {
+  await page.goto('http://localhost:3000/leaderboard')
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
+  await expect(page.getByRole('row').nth(1)).toBeVisible()
+})

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+interface LeaderboardEntry {
+  userId: string
+  elo: number
+  user: {
+    name: string | null
+  } | null
+}
+
+export default async function LeaderboardPage() {
+  const res = await fetch('http://localhost:3000/api/leaderboard', {
+    cache: 'no-store',
+  })
+  const data: LeaderboardEntry[] = await res.json()
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Leaderboard</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left border-b">Name</th>
+            <th className="px-4 py-2 text-left border-b">ELO</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((entry) => (
+            <tr key={entry.userId}>
+              <td className="px-4 py-2 border-b">
+                {entry.user?.name ?? 'Unknown'}
+              </td>
+              <td className="px-4 py-2 border-b">{entry.elo}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add server-rendered leaderboard page
- test leaderboard loads and shows a row

## Testing
- `pnpm lint` (fails: Unexpected token in next.config.ts)
- `pnpm exec eslint src/app/leaderboard/page.tsx e2e/leaderboard.spec.ts && echo 'eslint passed'`
- `pnpm typecheck` (fails: errors in next.config.ts and GameCanvas.tsx)
- `pnpm test` (fails: existing test failures)
- `pnpm e2e` (fails: web server could not start due to next.config.ts syntax error)


------
https://chatgpt.com/codex/tasks/task_e_689ad41f6334832886f2ca80180da0a7