### PR TITLE
Persist matchmaking pairing to database

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -1,29 +1,34 @@
 import { NextResponse } from 'next/server'
-import { randomUUID } from 'node:crypto'
 
 import { getServerAuthSession } from '@/lib/auth'
 import { redis } from '@/lib/redis'
+import { prisma } from '@/lib/prisma'
 
-export const runtime = 'edge'
+export const runtime = 'nodejs'
 
-export async function POST(_req: Request) {
+export async function POST(req: Request) {
   const session = await getServerAuthSession()
   if (!session?.user) {
     return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   }
   const userId = session.user.id
   try {
+    const { mode = 'classic' } = (await req.json().catch(() => ({}))) as {
+      mode?: string
+    }
     const opponent = await redis.lpop<string>('matchmaking:queue')
     if (!opponent) {
       await redis.rpush('matchmaking:queue', userId)
       return NextResponse.json({ queued: true })
     }
-    const matchId = randomUUID()
+    const match = await prisma.match.create({
+      data: { p1Id: opponent, p2Id: userId, mode, p1Score: 0, p2Score: 0 },
+    })
     await redis.set(
-      `match:${matchId}`,
+      `match:${match.id}`,
       JSON.stringify({ p1: opponent, p2: userId }),
     )
-    return NextResponse.json({ p1: opponent, p2: userId, matchId })
+    return NextResponse.json({ p1: opponent, p2: userId, matchId: match.id })
   } catch (err) {
     return NextResponse.json({ error: 'queue error' }, { status: 500 })
   }


### PR DESCRIPTION
## Summary
- create match record in Prisma when matchmaking pairs users
- return DB-generated match ID and keep Redis pairing
- test matchmaking route for DB insert and Redis pairing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed0f3f3c8328baf83c3381010932