### PR TITLE
feat: enqueue leaderboard recalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ graph LR
   C --> E[(Upstash Redis)]
 ```
 
+## Background jobs
+
+When a match score is reported, a message is published to the `leaderboard:recalc`
+Redis channel. A separate worker can subscribe to this channel and rebuild the
+leaderboard asynchronously.
+
 ## Offline Testing
 
 To verify the service worker's offline cache:

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/redis', () => ({
+  redis: {
+    publish: vi.fn(),
+  },
+}))
+
+import { triggerLeaderboardRecalculation } from './leaderboard'
+import { redis } from '@/lib/redis'
+
+describe('triggerLeaderboardRecalculation', () => {
+  it('publishes timestamp to redis channel', async () => {
+    await triggerLeaderboardRecalculation()
+    expect(redis.publish).toHaveBeenCalledWith(
+      'leaderboard:recalc',
+      expect.any(String),
+    )
+  })
+})

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,3 +1,6 @@
+import { redis } from '@/lib/redis'
+
 export async function triggerLeaderboardRecalculation() {
-  // placeholder for job queueing to recalc leaderboard
+  // enqueue a timestamp so a worker can recompute the leaderboard
+  await redis.publish('leaderboard:recalc', Date.now().toString())
 }


### PR DESCRIPTION
## Summary
- enqueue a timestamp on redis to trigger leaderboard recomputation
- test leaderboard job publishes to redis
- document leaderboard recalculation job

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689aed0ff1f4832890d090786f07f932