### PR TITLE
feat: add paddle control and scoring

### DIFF
--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -1,11 +1,23 @@
 import Phaser from 'phaser'
+import { aiMove, movePaddle } from './paddle'
+import { ScoreManager, Side } from './score'
 
 export default class MainScene extends Phaser.Scene {
   private ball!: Phaser.GameObjects.Arc
+  private player!: Phaser.GameObjects.Rectangle
+  private opponent!: Phaser.GameObjects.Rectangle
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
+  private playerScoreText!: Phaser.GameObjects.Text
+  private opponentScoreText!: Phaser.GameObjects.Text
   private velocity = new Phaser.Math.Vector2(200, 200)
+  private paddleSpeed = 300
+  private paddleHeight = 100
+  private score = new ScoreManager()
+  private matchId?: string
 
-  constructor() {
+  constructor(matchId?: string) {
     super('MainScene')
+    this.matchId = matchId
   }
 
   preload() {
@@ -15,18 +27,118 @@ export default class MainScene extends Phaser.Scene {
   create() {
     const { width, height } = this.scale
     this.ball = this.add.circle(width / 2, height / 2, 10, 0xffffff)
+    this.player = this.add.rectangle(
+      30,
+      height / 2,
+      20,
+      this.paddleHeight,
+      0xffffff,
+    )
+    this.opponent = this.add.rectangle(
+      width - 30,
+      height / 2,
+      20,
+      this.paddleHeight,
+      0xffffff,
+    )
+    this.cursors = this.input.keyboard.createCursorKeys()
+    this.playerScoreText = this.add
+      .text(width / 4, 20, '0', { color: '#fff', fontSize: '32px' })
+      .setOrigin(0.5, 0.5)
+    this.opponentScoreText = this.add
+      .text((width * 3) / 4, 20, '0', { color: '#fff', fontSize: '32px' })
+      .setOrigin(0.5, 0.5)
+
+    this.score.onMatchEnd((result) => {
+      this.events.emit('matchEnd', result)
+      if (this.matchId) {
+        fetch('/api/score', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            matchId: this.matchId,
+            p1Score: result.playerScore,
+            p2Score: result.opponentScore,
+          }),
+        }).catch(() => {})
+      }
+    })
+  }
+
+  private resetBall(direction: number) {
+    const { width, height } = this.scale
+    this.ball.setPosition(width / 2, height / 2)
+    this.velocity.set(200 * direction, Phaser.Math.Between(-200, 200))
+  }
+
+  private handleScore(side: Side) {
+    this.score.addPoint(side)
+    this.playerScoreText.setText(String(this.score.playerScore))
+    this.opponentScoreText.setText(String(this.score.opponentScore))
   }
 
   update(_time: number, delta: number) {
     const dt = delta / 1000
+
+    if (this.cursors.up?.isDown) {
+      this.player.y = movePaddle(
+        this.player.y,
+        -1,
+        this.paddleSpeed,
+        dt,
+        this.scale.height,
+        this.paddleHeight,
+      )
+    } else if (this.cursors.down?.isDown) {
+      this.player.y = movePaddle(
+        this.player.y,
+        1,
+        this.paddleSpeed,
+        dt,
+        this.scale.height,
+        this.paddleHeight,
+      )
+    }
+
+    this.opponent.y = aiMove(
+      this.opponent.y,
+      this.ball.y,
+      this.paddleSpeed,
+      dt,
+      this.scale.height,
+      this.paddleHeight,
+    )
+
     this.ball.x += this.velocity.x * dt
     this.ball.y += this.velocity.y * dt
 
-    if (this.ball.x <= 0 || this.ball.x >= this.scale.width) {
-      this.velocity.x *= -1
-    }
     if (this.ball.y <= 0 || this.ball.y >= this.scale.height) {
       this.velocity.y *= -1
+    }
+
+    if (this.ball.x < 0) {
+      this.handleScore('opponent')
+      this.resetBall(1)
+    } else if (this.ball.x > this.scale.width) {
+      this.handleScore('player')
+      this.resetBall(-1)
+    } else {
+      const ballBounds = this.ball.getBounds()
+      if (
+        Phaser.Geom.Intersects.RectangleToRectangle(
+          ballBounds,
+          this.player.getBounds(),
+        )
+      ) {
+        this.velocity.x = Math.abs(this.velocity.x)
+      } else if (
+        Phaser.Geom.Intersects.RectangleToRectangle(
+          ballBounds,
+          this.opponent.getBounds(),
+        )
+      ) {
+        this.velocity.x = -Math.abs(this.velocity.x)
+      }
     }
   }
 }

--- a/src/game/paddle.test.ts
+++ b/src/game/paddle.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { aiMove, movePaddle } from './paddle'
+
+describe('paddle movement', () => {
+  const screen = 200
+  const paddle = 100
+  const speed = 100
+  const dt = 1
+
+  it('moves up and down within bounds', () => {
+    expect(movePaddle(100, -1, speed, dt, screen, paddle)).toBe(50)
+    expect(movePaddle(50, -1, speed, dt, screen, paddle)).toBe(50)
+    expect(movePaddle(100, 1, speed, dt, screen, paddle)).toBe(150)
+    expect(movePaddle(150, 1, speed, dt, screen, paddle)).toBe(150)
+  })
+
+  it('AI moves toward the target', () => {
+    expect(aiMove(150, 50, speed, dt, screen, paddle)).toBe(50)
+    expect(aiMove(50, 150, speed, dt, screen, paddle)).toBe(150)
+  })
+})

--- a/src/game/paddle.ts
+++ b/src/game/paddle.ts
@@ -1,0 +1,26 @@
+export function movePaddle(
+  y: number,
+  direction: number,
+  speed: number,
+  dt: number,
+  screenHeight: number,
+  paddleHeight: number,
+): number {
+  let newY = y + direction * speed * dt
+  const half = paddleHeight / 2
+  if (newY < half) newY = half
+  if (newY > screenHeight - half) newY = screenHeight - half
+  return newY
+}
+
+export function aiMove(
+  currentY: number,
+  targetY: number,
+  speed: number,
+  dt: number,
+  screenHeight: number,
+  paddleHeight: number,
+): number {
+  const direction = targetY < currentY ? -1 : 1
+  return movePaddle(currentY, direction, speed, dt, screenHeight, paddleHeight)
+}

--- a/src/game/score.test.ts
+++ b/src/game/score.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ScoreManager } from './score'
+
+describe('ScoreManager', () => {
+  it('updates scores and emits match result', () => {
+    const score = new ScoreManager(2)
+    const handler = vi.fn()
+    score.onMatchEnd(handler)
+    score.addPoint('player')
+    expect(score.playerScore).toBe(1)
+    expect(handler).not.toHaveBeenCalled()
+    score.addPoint('player')
+    expect(score.playerScore).toBe(2)
+    expect(handler).toHaveBeenCalledWith({
+      winner: 'player',
+      playerScore: 2,
+      opponentScore: 0,
+    })
+  })
+})

--- a/src/game/score.ts
+++ b/src/game/score.ts
@@ -1,0 +1,39 @@
+export type Side = 'player' | 'opponent'
+
+export interface MatchResult {
+  winner: Side
+  playerScore: number
+  opponentScore: number
+}
+
+export class ScoreManager {
+  playerScore = 0
+  opponentScore = 0
+  private listeners: ((result: MatchResult) => void)[] = []
+
+  constructor(private winScore = 10) {}
+
+  addPoint(side: Side) {
+    if (side === 'player') {
+      this.playerScore++
+    } else {
+      this.opponentScore++
+    }
+
+    if (
+      this.playerScore >= this.winScore ||
+      this.opponentScore >= this.winScore
+    ) {
+      const result: MatchResult = {
+        winner: this.playerScore > this.opponentScore ? 'player' : 'opponent',
+        playerScore: this.playerScore,
+        opponentScore: this.opponentScore,
+      }
+      this.listeners.forEach((cb) => cb(result))
+    }
+  }
+
+  onMatchEnd(cb: (result: MatchResult) => void) {
+    this.listeners.push(cb)
+  }
+}


### PR DESCRIPTION
## Summary
- add player and AI-controlled opponent paddles
- implement ball collisions, scoring, and match end event with API call
- test paddle movement and scoring logic

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689aed1087748328b5d6ef2616f3e494