### PR TITLE
feat: show wins and losses on leaderboard

### DIFF
--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -3,5 +3,7 @@ import { test, expect } from '@playwright/test'
 test('leaderboard page lists players', async ({ page }) => {
   await page.goto('http://localhost:3000/leaderboard')
   await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Wins' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Losses' })).toBeVisible()
   await expect(page.getByRole('row').nth(1)).toBeVisible()
 })

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 interface LeaderboardEntry {
   userId: string
   elo: number
+  wins: number
+  losses: number
   user: {
     name: string | null
   } | null
@@ -22,6 +24,8 @@ export default async function LeaderboardPage() {
           <tr>
             <th className="px-4 py-2 text-left border-b">Name</th>
             <th className="px-4 py-2 text-left border-b">ELO</th>
+            <th className="px-4 py-2 text-left border-b">Wins</th>
+            <th className="px-4 py-2 text-left border-b">Losses</th>
           </tr>
         </thead>
         <tbody>
@@ -31,6 +35,8 @@ export default async function LeaderboardPage() {
                 {entry.user?.name ?? 'Unknown'}
               </td>
               <td className="px-4 py-2 border-b">{entry.elo}</td>
+              <td className="px-4 py-2 border-b">{entry.wins}</td>
+              <td className="px-4 py-2 border-b">{entry.losses}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- fetch leaderboard on server and display wins/losses
- check leaderboard page with Playwright

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm e2e` *(fails: Download failed: server returned code 403 body 'Domain forbidden'.)*

------
https://chatgpt.com/codex/tasks/task_e_689aed51c55c83288d20ca6a658e7b06