### PR TITLE
Load Phaser dynamically in GameCanvas

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1,33 +1,46 @@
 'use client'
 
-import Phaser from 'phaser'
 import { useEffect, useRef } from 'react'
 
 import MainScene from '../game/MainScene'
 import { useSettings } from '../store/settings'
 
+type Phaser = typeof import('phaser')
+
 export function GameCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
-  const gameRef = useRef<Phaser.Game>()
+  const gameRef = useRef<Phaser.Game | null>(null)
   const muted = useSettings((s) => s.muted)
 
   useEffect(() => {
     if (!containerRef.current) return
 
-    const config: Phaser.Types.Core.GameConfig = {
-      type: Phaser.AUTO,
-      parent: containerRef.current,
-      width: containerRef.current.clientWidth,
-      height: containerRef.current.clientHeight,
-      scene: MainScene,
+    let ignore = false
+
+    const init = async () => {
+      const Phaser: Phaser = await import('phaser')
+
+      const config: Phaser.Types.Core.GameConfig = {
+        type: Phaser.AUTO,
+        parent: containerRef.current!,
+        width: containerRef.current!.clientWidth,
+        height: containerRef.current!.clientHeight,
+        scene: MainScene,
+      }
+
+      if (ignore) return
+
+      const game = new Phaser.Game(config)
+      game.sound.mute = muted
+      gameRef.current = game
     }
 
-    const game = new Phaser.Game(config)
-    gameRef.current = game
+    init()
 
     return () => {
-      game.destroy(true)
-      gameRef.current = undefined
+      ignore = true
+      gameRef.current?.destroy(true)
+      gameRef.current = null
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
## Summary
- Load Phaser on demand within `GameCanvas` to avoid top-level import
- Ensure initial mute state and sound toggling continue to work

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient', multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_689aed529294832886118ce3e549ad84