### PR TITLE
Handle score submission errors

### DIFF
--- a/src/game/MainScene.test.ts
+++ b/src/game/MainScene.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import MainScene from './MainScene'
+import { ScoreManager } from './score'
+
+vi.mock('phaser', () => {
+  class Scene {
+    add = {
+      circle: vi.fn(() => ({})),
+      rectangle: vi.fn(() => ({})),
+      text: vi.fn(() => ({ setOrigin: vi.fn().mockReturnThis() })),
+    }
+    input = { keyboard: { createCursorKeys: vi.fn(() => ({})) } }
+    events = { emit: vi.fn() }
+    scale = { width: 800, height: 600 }
+  }
+  class Vector2 {
+    x: number
+    y: number
+    constructor(x: number, y: number) {
+      this.x = x
+      this.y = y
+    }
+    set(x: number, y: number) {
+      this.x = x
+      this.y = y
+    }
+  }
+  return {
+    default: {
+      Scene,
+      Math: { Vector2 },
+      Geom: { Intersects: { RectangleToRectangle: vi.fn() } },
+    },
+  }
+})
+
+describe('MainScene', () => {
+  it('logs an error when score submission fails', async () => {
+    const scene = new MainScene('match')
+    Object.assign(scene as object, { score: new ScoreManager(1) })
+    scene.create()
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock
+    ;(scene as unknown as { score: ScoreManager }).score.addPoint('player')
+    await Promise.resolve()
+
+    expect(errorSpy).toHaveBeenCalled()
+  })
+})

--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -49,18 +49,25 @@ export default class MainScene extends Phaser.Scene {
       .text((width * 3) / 4, 20, '0', { color: '#fff', fontSize: '32px' })
       .setOrigin(0.5, 0.5)
 
-    this.score.onMatchEnd((result) => {
+    this.score.onMatchEnd(async (result) => {
       this.events.emit('matchEnd', result)
       if (this.matchId) {
-        fetch('/api/score', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            matchId: this.matchId,
-            p1Score: result.playerScore,
-            p2Score: result.opponentScore,
-          }),
-        }).catch(() => {})
+        try {
+          const response = await fetch('/api/score', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              matchId: this.matchId,
+              p1Score: result.playerScore,
+              p2Score: result.opponentScore,
+            }),
+          })
+          if (!response.ok) {
+            console.error('Failed to submit score')
+          }
+        } catch (error) {
+          console.error('Failed to submit score', error)
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary
- await score submission request and surface errors when it fails
- test that a failed score submission logs an error

## Testing
- `pnpm test src/game/MainScene.test.ts`
- `pnpm test` *(fails: Unexpected `}` in src/lib/leaderboard.test.ts)*
- `npx eslint src/game/MainScene.test.ts`
- `pnpm lint` *(fails: Unexpected any and parsing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689afc1177cc8328bd5618e823854ad4