### PR TITLE
feat: trigger leaderboard recalculation

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+vi.mock('./redis', () => ({
+  redis: {
+    publish: vi.fn(),
   },
 }))
 
 import { triggerLeaderboardRecalculation } from './leaderboard'
+import { redis } from './redis'
 
+describe('triggerLeaderboardRecalculation', () => {
+  it('publishes leaderboard:recalc to redis', async () => {
+    await triggerLeaderboardRecalculation()
+    expect(redis.publish).toHaveBeenCalledWith('leaderboard:recalc', '')
   })
 })

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,5 @@
+import { redis } from '@/lib/redis'
+
+export function triggerLeaderboardRecalculation() {
+  return redis.publish('leaderboard:recalc', '')
+}


### PR DESCRIPTION
## Summary
- add helper to publish leaderboard:recalc message to redis
- test leaderboard recalculation trigger publishes to redis

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0e6785708328af2ee6f481196008