### PR TITLE
Handle leaderboard API fetch errors

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -11,36 +11,51 @@ interface LeaderboardEntry {
 }
 
 export default async function LeaderboardPage() {
-  const res = await fetch('http://localhost:3000/api/leaderboard', {
-    cache: 'no-store',
-  })
-  const data: LeaderboardEntry[] = await res.json()
+  try {
+    const res = await fetch('/api/leaderboard', {
+      cache: 'no-store',
+    })
 
-  return (
-    <main className="p-8">
-      <h1 className="mb-4 text-3xl font-bold">Leaderboard</h1>
-      <table className="min-w-full border">
-        <thead>
-          <tr>
-            <th className="px-4 py-2 text-left border-b">Name</th>
-            <th className="px-4 py-2 text-left border-b">ELO</th>
-            <th className="px-4 py-2 text-left border-b">Wins</th>
-            <th className="px-4 py-2 text-left border-b">Losses</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((entry) => (
-            <tr key={entry.userId}>
-              <td className="px-4 py-2 border-b">
-                {entry.user?.name ?? 'Unknown'}
-              </td>
-              <td className="px-4 py-2 border-b">{entry.elo}</td>
-              <td className="px-4 py-2 border-b">{entry.wins}</td>
-              <td className="px-4 py-2 border-b">{entry.losses}</td>
+    if (!res.ok) {
+      throw new Error('Failed to fetch leaderboard')
+    }
+
+    const data: LeaderboardEntry[] = await res.json()
+
+    return (
+      <main className="p-8">
+        <h1 className="mb-4 text-3xl font-bold">Leaderboard</h1>
+        <table className="min-w-full border">
+          <thead>
+            <tr>
+              <th className="px-4 py-2 text-left border-b">Name</th>
+              <th className="px-4 py-2 text-left border-b">ELO</th>
+              <th className="px-4 py-2 text-left border-b">Wins</th>
+              <th className="px-4 py-2 text-left border-b">Losses</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </main>
-  )
+          </thead>
+          <tbody>
+            {data.map((entry) => (
+              <tr key={entry.userId}>
+                <td className="px-4 py-2 border-b">
+                  {entry.user?.name ?? 'Unknown'}
+                </td>
+                <td className="px-4 py-2 border-b">{entry.elo}</td>
+                <td className="px-4 py-2 border-b">{entry.wins}</td>
+                <td className="px-4 py-2 border-b">{entry.losses}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    )
+  } catch (error) {
+    console.error('Failed to load leaderboard:', error)
+    return (
+      <main className="p-8">
+        <h1 className="mb-4 text-3xl font-bold">Leaderboard</h1>
+        <p>Unable to load leaderboard data.</p>
+      </main>
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- use relative `/api/leaderboard` path instead of hard-coded localhost
- wrap leaderboard fetch in try/catch and render friendly fallback

## Testing
- `pnpm lint --file src/app/leaderboard/page.tsx`
- `pnpm test` *(fails: Unexpected "}" in src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e68b3e08328ab79f4c62d05f8cb