### PR TITLE
Prevent duplicate matchmaking queue entries with TTL

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/redis', () => {
     incr: vi.fn().mockResolvedValue(1),
     expire: vi.fn().mockResolvedValue(null),
     lpop: vi.fn(),
+    lpos: vi.fn(),
     rpush: vi.fn(),
     set: vi.fn(),
     del: vi.fn(),
@@ -40,6 +41,5 @@ function jsonRequest(body: unknown, init: RequestInit = {}) {
 export {}
 
 declare global {
-  // eslint-disable-next-line no-var
   var jsonRequest: typeof jsonRequest
 }


### PR DESCRIPTION
## Summary
- ensure users are enqueued only once in matchmaking and refresh TTL
- add tests for duplicate suppression and TTL logic
- mock Redis `lpos` in test setup

## Testing
- `pnpm exec eslint src/app/api/matchmaking/route.ts src/app/api/matchmaking/route.test.ts vitest.setup.ts`
- `pnpm test src/app/api/matchmaking/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b0e6ad2308328bacb0779351ff3da