### PR TITLE
Add mute toggle button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { AnalyticsProvider } from '../components/AnalyticsProvider'
 import { AuthButtons } from '../components/AuthButtons'
+import { MuteButton } from '../components/MuteButton'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getLocale, getTranslations } from 'next-intl/server'
 
@@ -40,8 +41,9 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AnalyticsProvider />
-          <header className="p-4">
+          <header className="p-4 flex gap-2">
             <AuthButtons />
+            <MuteButton />
           </header>
           {children}
         </NextIntlClientProvider>

--- a/src/components/MuteButton.test.tsx
+++ b/src/components/MuteButton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MuteButton } from './MuteButton'
+import { useSettings } from '../store/settings'
+
+beforeEach(() => {
+  useSettings.persist.clearStorage()
+  localStorage.clear()
+  useSettings.setState({ muted: false })
+})
+
+describe('MuteButton', () => {
+  it('toggles muted state and updates label', () => {
+    render(<MuteButton />)
+    const button = screen.getByRole('button')
+    expect(button).toHaveTextContent('Mute')
+
+    fireEvent.click(button)
+    expect(button).toHaveTextContent('Unmute')
+    expect(useSettings.getState().muted).toBe(true)
+
+    fireEvent.click(button)
+    expect(button).toHaveTextContent('Mute')
+    expect(useSettings.getState().muted).toBe(false)
+  })
+})

--- a/src/components/MuteButton.tsx
+++ b/src/components/MuteButton.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import React from 'react'
+import { useSettings } from '../store/settings'
+
+export function MuteButton() {
+  const muted = useSettings((s) => s.muted)
+  const toggleMuted = useSettings((s) => s.toggleMuted)
+
+  return (
+    <button onClick={toggleMuted} aria-label={muted ? 'Unmute' : 'Mute'}>
+      {muted ? 'Unmute' : 'Mute'}
+    </button>
+  )
+}
+
+export default MuteButton


### PR DESCRIPTION
## Summary
- add MuteButton component to toggle audio
- wire MuteButton into layout header next to auth controls
- test mute button toggling

## Testing
- `pnpm test` *(fails: Unexpected "}" in src/lib/leaderboard.test.ts)*
- `pnpm test src/components/MuteButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b0e6d9f8c83288931aaf8e0825092