### PR TITLE
Handle leaderboard query errors and add tests

### DIFF
--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    leaderboard: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+import { GET } from './route'
+import { prisma } from '@/lib/prisma'
+
+describe('leaderboard API', () => {
+  it('returns leaderboard entries', async () => {
+    const sample = [
+      { id: '1', elo: 1000, user: { id: 'u1', name: 'Alice' } },
+      { id: '2', elo: 900, user: { id: 'u2', name: 'Bob' } },
+    ]
+
+    prisma.leaderboard.findMany.mockResolvedValue(sample as any)
+
+    const res = await GET()
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual(sample)
+  })
+
+  it('returns 500 on query failure', async () => {
+    prisma.leaderboard.findMany.mockRejectedValue(new Error('boom'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'server error' })
+  })
+})

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -2,10 +2,14 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
-  const data = await prisma.leaderboard.findMany({
-    take: 10,
-    orderBy: { elo: 'desc' },
-    include: { user: true },
-  })
-  return NextResponse.json(data)
+  try {
+    const data = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      include: { user: true },
+    })
+    return NextResponse.json(data)
+  } catch {
+    return NextResponse.json({ error: 'server error' }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary
- wrap leaderboard query in try/catch and return 500 on failure
- add leaderboard route tests for success and failure cases

## Testing
- `pnpm test src/app/api/leaderboard/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b8bfb78848328bc9bc72575b7d73d