### PR TITLE
test: verify leaderboard recalc publish

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
 
+vi.mock('./redis', () => ({
+  redis: {
+    publish: vi.fn(),
+  },
+}))
 
 import { triggerLeaderboardRecalculation } from './leaderboard'
 import { redis } from './redis'
 
+describe('triggerLeaderboardRecalculation', () => {
+  it('publishes recalc event and returns result', async () => {
+    const publishResult = 1
+    const publishMock = vi.mocked(redis.publish)
+    publishMock.mockResolvedValue(publishResult)
 
+    const result = await triggerLeaderboardRecalculation()
+
+    expect(publishMock).toHaveBeenCalledWith('leaderboard:recalc', '')
+    expect(result).toBe(publishResult)
+  })
 })


### PR DESCRIPTION
## Summary
- add unit test for leaderboard recalculation

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8bfc61008328952108ca2c4577e1