### PR TITLE
refactor: remove default MuteButton export

### DIFF
--- a/src/components/MuteButton.tsx
+++ b/src/components/MuteButton.tsx
@@ -3,15 +3,18 @@
 import React from 'react'
 import { useSettings } from '../store/settings'
 
-export function MuteButton() {
+export function MuteButton({ className }: { className?: string }) {
   const muted = useSettings((s) => s.muted)
   const toggleMuted = useSettings((s) => s.toggleMuted)
 
   return (
-    <button onClick={toggleMuted} aria-label={muted ? 'Unmute' : 'Mute'}>
+    <button
+      type="button"
+      className={className}
+      onClick={toggleMuted}
+      aria-label={muted ? 'Unmute' : 'Mute'}
+    >
       {muted ? 'Unmute' : 'Mute'}
     </button>
   )
 }
-
-export default MuteButton


### PR DESCRIPTION
## Summary
- remove default export from MuteButton
- add optional className and button type

## Testing
- `pnpm test` *(fails: Unexpected "}" in src/lib/leaderboard.test.ts)*
- `pnpm lint` *(fails: ESLint errors in src/components/GameCanvas.test.tsx and src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b8bfd5ecc83289347b6215984848f