### PR TITLE
feat: add unsubscribe for match end listeners

### DIFF
--- a/src/game/MainScene.test.ts
+++ b/src/game/MainScene.test.ts
@@ -10,7 +10,7 @@ vi.mock('phaser', () => {
       text: vi.fn(() => ({ setOrigin: vi.fn().mockReturnThis() })),
     }
     input = { keyboard: { createCursorKeys: vi.fn(() => ({})) } }
-    events = { emit: vi.fn() }
+    events = { emit: vi.fn(), once: vi.fn() }
     scale = { width: 800, height: 600 }
   }
   class Vector2 {
@@ -30,6 +30,7 @@ vi.mock('phaser', () => {
       Scene,
       Math: { Vector2 },
       Geom: { Intersects: { RectangleToRectangle: vi.fn() } },
+      Scenes: { Events: { DESTROY: 'destroy' } },
     },
   }
 })

--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -49,7 +49,7 @@ export default class MainScene extends Phaser.Scene {
       .text((width * 3) / 4, 20, '0', { color: '#fff', fontSize: '32px' })
       .setOrigin(0.5, 0.5)
 
-    this.score.onMatchEnd(async (result) => {
+    const unsubscribe = this.score.onMatchEnd(async (result) => {
       this.events.emit('matchEnd', result)
       if (this.matchId) {
         try {
@@ -70,6 +70,7 @@ export default class MainScene extends Phaser.Scene {
         }
       }
     })
+    this.events.once(Phaser.Scenes.Events.DESTROY, unsubscribe)
   }
 
   private resetBall(direction: number) {

--- a/src/game/score.test.ts
+++ b/src/game/score.test.ts
@@ -17,4 +17,13 @@ describe('ScoreManager', () => {
       opponentScore: 0,
     })
   })
+
+  it('removes listeners when unsubscribe is called', () => {
+    const score = new ScoreManager(1)
+    const handler = vi.fn()
+    const unsubscribe = score.onMatchEnd(handler)
+    unsubscribe()
+    score.addPoint('player')
+    expect(handler).not.toHaveBeenCalled()
+  })
 })

--- a/src/game/score.ts
+++ b/src/game/score.ts
@@ -35,5 +35,8 @@ export class ScoreManager {
 
   onMatchEnd(cb: (result: MatchResult) => void) {
     this.listeners.push(cb)
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== cb)
+    }
   }
 }

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 
-
 import { triggerLeaderboardRecalculation } from './leaderboard'
 import { redis } from './redis'
 
+vi.mock('./redis', () => ({
+  redis: { publish: vi.fn() },
+}))
 
+describe('leaderboard', () => {
+  it('publishes a recalculation message', () => {
+    triggerLeaderboardRecalculation()
+    expect(redis.publish).toHaveBeenCalledWith('leaderboard:recalc', '')
+  })
 })


### PR DESCRIPTION
## Summary
- add unsubscribe capability to ScoreManager.onMatchEnd
- verify listeners can be removed in score tests
- clean up match end listener in MainScene and adjust mocks
- fix incomplete leaderboard test to keep suite passing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8bfde3148328b9efeb0ed1855d7f