### PR TITLE
refactor: query leaderboard directly in page

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+export const leaderboardQueryOptions = {
+  take: 10,
+  orderBy: { elo: 'desc' },
+  include: { user: true },
+} as const
+
 export async function GET() {
   try {
-    const data = await prisma.leaderboard.findMany({
-      take: 10,
-      orderBy: { elo: 'desc' },
-      include: { user: true },
-    })
+    const data = await prisma.leaderboard.findMany(leaderboardQueryOptions)
     return NextResponse.json(data)
   } catch {
     return NextResponse.json({ error: 'server error' }, { status: 500 })

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { prisma } from '@/lib/prisma'
+import { leaderboardQueryOptions } from '@/app/api/leaderboard/route'
 
 interface LeaderboardEntry {
   userId: string
@@ -12,15 +14,9 @@ interface LeaderboardEntry {
 
 export default async function LeaderboardPage() {
   try {
-    const res = await fetch('/api/leaderboard', {
-      cache: 'no-store',
-    })
-
-    if (!res.ok) {
-      throw new Error('Failed to fetch leaderboard')
-    }
-
-    const data: LeaderboardEntry[] = await res.json()
+    const data: LeaderboardEntry[] = await prisma.leaderboard.findMany(
+      leaderboardQueryOptions,
+    )
 
     return (
       <main className="p-8">


### PR DESCRIPTION
## Summary
- query Prisma directly for leaderboard data in page component
- centralize leaderboard Prisma query options for reuse

## Testing
- `pnpm test` *(fails: No test suite found in file src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689be7b946908328ae66de7458039a42