### PR TITLE
feat: add API response helpers

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, error } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -8,8 +8,8 @@ export async function GET() {
       orderBy: { elo: 'desc' },
       include: { user: true },
     })
-    return NextResponse.json(data)
+    return ok(data)
   } catch {
-    return NextResponse.json({ error: 'server error' }, { status: 500 })
+    return error('server error', 500)
   }
 }

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export function ok<T>(data: T, init?: ResponseInit) {
+  return NextResponse.json(data, init)
+}
+
+export function error(message: string, status = 500) {
+  console.error('API error', { status, message })
+  return NextResponse.json({ error: message }, { status })
+}


### PR DESCRIPTION
## Summary
- add reusable API response helpers with centralized error logging
- refactor API routes to use helpers

## Testing
- `pnpm lint` (fails: Unexpected any, Unexpected var, React Hook useEffect missing dependency)
- `pnpm prisma generate` (fails: Failed to fetch sha256 checksum - 403 Forbidden)
- `pnpm typecheck` (fails: Cannot find type definition file for '@prisma/client')
- `pnpm test` (fails: No test suite found in file src/lib/leaderboard.test.ts)


------
https://chatgpt.com/codex/tasks/task_e_689be7baa1348328a61a80f14f821662