### PR TITLE
test: ensure offline gameplay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test
-      - run: pnpm e2e -- --browser=chromium || true
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm e2e --browser=chromium

--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ leaderboard asynchronously.
 
 ## Offline Testing
 
-To verify the service worker's offline cache:
+The Playwright suite includes an automated offline test:
+
+```bash
+pnpm e2e --browser=chromium
+```
+
+It launches the app, waits for the service worker to register, disables
+network access, and ensures the `GameCanvas` continues animating.
+
+To verify manually:
 
 1. Run `pnpm dev` and open the app in your browser.
 2. In DevTools, confirm the service worker is registered under **Application → Service Workers**.

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+test('game continues offline after service worker registration', async ({
+  page,
+}) => {
+  await page.goto('http://localhost:3000')
+  await page.waitForSelector('canvas')
+  await page.waitForFunction(() => navigator.serviceWorker?.controller)
+
+  await page.context().setOffline(true)
+  await expect(await page.evaluate(() => navigator.onLine)).toBe(false)
+  await expect(page.locator('canvas')).toBeVisible()
+
+  const frame1 = await page.evaluate(() =>
+    document.querySelector('canvas')?.toDataURL(),
+  )
+  await page.waitForTimeout(500)
+  const frame2 = await page.evaluate(() =>
+    document.querySelector('canvas')?.toDataURL(),
+  )
+  expect(frame1).not.toBe(frame2)
+})


### PR DESCRIPTION
## Summary
- add Playwright test covering offline gameplay after service worker registration
- document running the offline test
- run e2e tests in CI with browser installation

## Testing
- `pnpm test` *(fails: No test suite found in src/lib/leaderboard.test.ts)*
- `pnpm e2e --browser=chromium` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689be7bce2248328aeb457b8a9b8f425