### PR TITLE
Use Prisma for leaderboard

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { prisma } from '@/lib/prisma'
 
 interface LeaderboardEntry {
   userId: string
@@ -12,15 +13,11 @@ interface LeaderboardEntry {
 
 export default async function LeaderboardPage() {
   try {
-    const res = await fetch('/api/leaderboard', {
-      cache: 'no-store',
+    const data: LeaderboardEntry[] = await prisma.leaderboard.findMany({
+      take: 10,
+      orderBy: { elo: 'desc' },
+      include: { user: true },
     })
-
-    if (!res.ok) {
-      throw new Error('Failed to fetch leaderboard')
-    }
-
-    const data: LeaderboardEntry[] = await res.json()
 
     return (
       <main className="p-8">


### PR DESCRIPTION
## Summary
- query leaderboard directly with Prisma instead of calling API

## Testing
- `pnpm test` *(fails: No test suite found in file /workspace/pong/src/lib/leaderboard.test.ts)*
- `pnpm lint` *(fails: Unexpected any / var in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c08f0d57083288403cbc9066d359c