### PR TITLE
feat: add profile page and API

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+const bodySchema = z.object({
+  displayName: z.string().trim().min(1).max(100).optional(),
+  avatarUrl: z.string().url().optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const formData = await req.formData()
+  const data = {
+    displayName: (formData.get('displayName') as string) || undefined,
+    avatarUrl: (formData.get('avatarUrl') as string) || undefined,
+  }
+  const parsed = bodySchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+  const { displayName, avatarUrl } = parsed.data
+  await prisma.profile.upsert({
+    where: { userId: session.user.id },
+    update: { displayName: displayName ?? null, avatarUrl: avatarUrl ?? null },
+    create: {
+      userId: session.user.id,
+      displayName: displayName ?? null,
+      avatarUrl: avatarUrl ?? null,
+    },
+  })
+  return NextResponse.redirect(new URL('/profile', req.url), 303)
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation'
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    redirect('/api/auth/signin?callbackUrl=/profile')
+  }
+  const profile = await prisma.profile.findUnique({
+    where: { userId: session.user.id },
+  })
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Profile</h1>
+      <form method="POST" action="/api/profile" className="space-y-4">
+        <div>
+          <label htmlFor="displayName" className="mb-1 block">
+            Display Name
+          </label>
+          <input
+            id="displayName"
+            name="displayName"
+            defaultValue={profile?.displayName ?? ''}
+            className="w-full border px-2 py-1"
+          />
+        </div>
+        <div>
+          <label htmlFor="avatarUrl" className="mb-1 block">
+            Avatar URL
+          </label>
+          <input
+            id="avatarUrl"
+            name="avatarUrl"
+            defaultValue={profile?.avatarUrl ?? ''}
+            className="w-full border px-2 py-1"
+          />
+        </div>
+        <button
+          type="submit"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+        >
+          Save
+        </button>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add profile page with form loading session profile
- add API route to validate input and upsert profile

## Testing
- `pnpm test` (fails: No test suite found in file src/lib/leaderboard.test.ts)
- `pnpm lint` (fails: ESLint errors in existing files)
- `pnpm typecheck` (fails: Cannot find type definition file for '@prisma/client')

------
https://chatgpt.com/codex/tasks/task_e_689c08f2722c8328a0578832e329fb33