### PR TITLE
feat: add API response helpers and refactor routes

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, error } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -8,8 +8,8 @@ export async function GET() {
       orderBy: { elo: 'desc' },
       include: { user: true },
     })
-    return NextResponse.json(data)
+    return ok(data)
   } catch {
-    return NextResponse.json({ error: 'server error' }, { status: 500 })
+    return error('server error', 500)
   }
 }

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,10 @@
+import { NextResponse, type NextResponseInit } from 'next/server'
+
+export function ok<T>(data: T, init: NextResponseInit = {}) {
+  return NextResponse.json(data, init)
+}
+
+export function error(message: string, status: number) {
+  console.error('API error', { message, status })
+  return NextResponse.json({ error: message }, { status })
+}

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('./redis', () => ({
+  redis: {
+    publish: vi.fn(),
+  },
+}))
+
+import { triggerLeaderboardRecalculation } from './leaderboard'
+import { redis } from './redis'
+
+describe('leaderboard', () => {
+  it('triggers recalculation', async () => {
+    await triggerLeaderboardRecalculation()
+    expect(redis.publish).toHaveBeenCalledWith('leaderboard:recalc', '')
+  })
+})


### PR DESCRIPTION
## Summary
- add reusable `ok` and `error` helpers for API responses
- refactor score, matchmaking, leaderboard, and telemetry routes to use helpers
- log details in centralized `error` helper
- add basic leaderboard recalculation test

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unexpected any, no-var, react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_689c08f1c5688328ae019d265df72c69