### PR TITLE
feat: add profile page and API route

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { error } from '@/lib/api-response'
+
+const profileSchema = z.object({
+  displayName: z.string().optional(),
+  avatarUrl: z.string().url().optional().or(z.literal('')),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return error('unauthorized', 401)
+  }
+  const formData = await req.formData()
+  const body = {
+    displayName: formData.get('displayName')?.toString(),
+    avatarUrl: formData.get('avatarUrl')?.toString(),
+  }
+  const parsed = profileSchema.safeParse(body)
+  if (!parsed.success) {
+    return error('invalid', 400)
+  }
+  const { displayName, avatarUrl } = parsed.data
+  await prisma.profile.upsert({
+    where: { userId: session.user.id },
+    create: {
+      userId: session.user.id,
+      displayName,
+      avatarUrl: avatarUrl || undefined,
+    },
+    update: { displayName, avatarUrl: avatarUrl || undefined },
+  })
+  return NextResponse.redirect(new URL('/profile', req.url))
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation'
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    redirect('/api/auth/signin')
+  }
+  const profile = await prisma.profile.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Profile</h1>
+      <form action="/api/profile" method="POST" className="flex flex-col gap-4">
+        <label className="flex flex-col">
+          <span>Display Name</span>
+          <input
+            name="displayName"
+            defaultValue={profile?.displayName ?? ''}
+            className="border p-2"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Avatar URL</span>
+          <input
+            name="avatarUrl"
+            defaultValue={profile?.avatarUrl ?? ''}
+            className="border p-2"
+          />
+        </label>
+        <button
+          type="submit"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+        >
+          Save
+        </button>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add profile page with user form
- add API route to validate and upsert profile

## Testing
- `pnpm lint` (fails: Unexpected any etc.)
- `pnpm test` (fails: No test suite found, TypeError in leaderboard tests)


------
https://chatgpt.com/codex/tasks/task_e_689c18725d0c8328b689fe09c1547d35