### PR TITLE
feat: add spectate channel and page

### DIFF
--- a/src/app/match/[id]/spectate/page.tsx
+++ b/src/app/match/[id]/spectate/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import { useParams } from 'next/navigation'
+
+import { GameCanvas } from '@/components/GameCanvas'
+
+export default function SpectatePage() {
+  const { id } = useParams<{ id: string }>()
+  const [status, setStatus] = useState<'live' | 'ended' | 'disconnected'>(
+    'live',
+  )
+
+  if (status === 'ended') {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <p>Match ended</p>
+      </main>
+    )
+  }
+
+  if (status === 'disconnected') {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <p>Disconnected from match</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center">
+      <GameCanvas
+        matchId={id}
+        spectator
+        onMatchEnd={() => setStatus('ended')}
+        onDisconnect={() => setStatus('disconnected')}
+      />
+    </main>
+  )
+}

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1,14 +1,27 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import type Phaser from 'phaser'
 
 import { usePhaserGame } from '../hooks/usePhaserGame'
 import { useSettings } from '../store/settings'
 
-export function GameCanvas() {
+interface GameCanvasProps {
+  matchId?: string
+  spectator?: boolean
+  onMatchEnd?: (result: unknown) => void
+  onDisconnect?: () => void
+}
+
+export function GameCanvas({
+  matchId,
+  spectator = false,
+  onMatchEnd,
+  onDisconnect,
+}: GameCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const muted = useSettings((s) => s.muted)
-  const gameRef = usePhaserGame(containerRef, muted)
+  const gameRef = usePhaserGame(containerRef, muted, matchId, spectator)
 
   useEffect(() => {
     const handleResize = () => {
@@ -23,7 +36,23 @@ export function GameCanvas() {
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [])
+  }, [gameRef])
+
+  useEffect(() => {
+    if (!onMatchEnd && !onDisconnect) return
+    const scene = gameRef.current?.scene.getScene('MainScene') as
+      | Phaser.Scene
+      | undefined
+    if (!scene) return
+
+    if (onMatchEnd) scene.events.once('matchEnd', onMatchEnd)
+    if (onDisconnect) scene.events.once('channelDisconnect', onDisconnect)
+
+    return () => {
+      if (onMatchEnd) scene.events.off('matchEnd', onMatchEnd)
+      if (onDisconnect) scene.events.off('channelDisconnect', onDisconnect)
+    }
+  }, [gameRef, onMatchEnd, onDisconnect])
 
   return <div ref={containerRef} className="w-full h-full" />
 }

--- a/src/hooks/usePhaserGame.ts
+++ b/src/hooks/usePhaserGame.ts
@@ -8,6 +8,8 @@ export type PhaserModule = typeof import('phaser')
 export function usePhaserGame(
   containerRef: React.RefObject<HTMLDivElement>,
   muted: boolean,
+  matchId?: string,
+  spectator = false,
 ) {
   const gameRef = useRef<PhaserModule.Game | null>(null)
 
@@ -22,7 +24,7 @@ export function usePhaserGame(
           parent: containerRef.current!,
           width: containerRef.current!.clientWidth,
           height: containerRef.current!.clientHeight,
-          scene: MainScene,
+          scene: [new MainScene(matchId, spectator)],
         }
         gameRef.current = new Phaser.Game(config)
       }
@@ -30,7 +32,7 @@ export function usePhaserGame(
     }
 
     void init()
-  }, [muted, containerRef])
+  }, [muted, containerRef, matchId, spectator])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- publish match updates to a dedicated `match:{id}:spectate` channel
- add read-only spectating mode for `MainScene`
- create `/match/[id]/spectate` page that shows match and handles disconnects

## Testing
- `pnpm lint` *(fails: Unexpected any/use of var in existing tests)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: 4 test files failed, 6 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c2d9c271083288b32f3fcc3848c30