### PR TITLE
feat: add language switcher

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { AnalyticsProvider } from '../components/AnalyticsProvider'
 import { AuthButtons } from '../components/AuthButtons'
+import { LanguageSwitcher } from '../components/LanguageSwitcher'
 import { MuteButton } from '../components/MuteButton'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getLocale, getTranslations } from 'next-intl/server'
@@ -43,6 +44,7 @@ export default async function RootLayout({
           <AnalyticsProvider />
           <header className="p-4 flex gap-2">
             <AuthButtons />
+            <LanguageSwitcher />
             <MuteButton />
           </header>
           {children}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { createNavigation } from 'next-intl/navigation'
+import { useLocale } from 'next-intl'
+import { locales } from '../i18n'
+
+const { usePathname, useRouter } = createNavigation()
+
+export function LanguageSwitcher() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const locale = useLocale()
+
+  return (
+    <div className="flex gap-2">
+      {locales.map((loc) => (
+        <button
+          key={loc}
+          onClick={() => router.replace(pathname, { locale: loc })}
+          className={loc === locale ? 'font-bold underline' : ''}
+        >
+          {loc.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default LanguageSwitcher


### PR DESCRIPTION
## Summary
- add LanguageSwitcher component using next-intl to switch locales via URL
- render LanguageSwitcher in layout header alongside AuthButtons

## Testing
- `pnpm lint` *(fails: Unexpected any, etc.)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c88c71ae48328965167d944b69e66