### PR TITLE
Handle leaderboard query with error handling and tests

### DIFF
--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/prisma', () => ({
   },
 }))
 
-import { GET } from './route'
+import { GET, leaderboardQueryOptions } from './route'
 import { prisma } from '@/lib/prisma'
 
 describe('leaderboard API', () => {
@@ -18,13 +18,16 @@ describe('leaderboard API', () => {
       { id: '2', elo: 900, user: { id: 'u2', name: 'Bob' } },
     ]
 
-    prisma.leaderboard.findMany.mockResolvedValue(sample as any)
+    prisma.leaderboard.findMany.mockResolvedValue(sample)
 
     const res = await GET()
     const json = await res.json()
 
     expect(res.status).toBe(200)
     expect(json).toEqual(sample)
+    expect(prisma.leaderboard.findMany).toHaveBeenCalledWith(
+      leaderboardQueryOptions,
+    )
   })
 
   it('returns 500 on query failure', async () => {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -9,7 +9,10 @@ export const leaderboardQueryOptions = {
 
 export async function GET() {
   try {
-
+    const leaderboard = await prisma.leaderboard.findMany(
+      leaderboardQueryOptions,
+    )
+    return ok(leaderboard)
   } catch {
     return error('server error', 500)
   }


### PR DESCRIPTION
## Summary
- Query Prisma for leaderboard using predefined options and wrap results with `ok`
- Add unit tests for leaderboard API covering success and error paths

## Testing
- `pnpm test src/app/api/leaderboard/route.test.ts`
- `pnpm lint src` *(fails: Unexpected any and other lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c88c4666c83288a6d79c3bffbbc51