### PR TITLE
Remove duplicate resolve alias in Vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,4 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**'],
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- remove redundant `resolve` block in Vitest configuration

## Testing
- `pnpm test` *(fails: No test suite found in file /workspace/pong/src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1fd28a08328bf4b7ce95dbe32e7