### PR TITLE
Add profile editor page and API endpoint

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { error } from '@/lib/api-response'
+
+const bodySchema = z.object({
+  displayName: z.string().optional(),
+  avatarUrl: z.union([z.string().url(), z.literal('')]).optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/api/auth/signin', req.url))
+  }
+
+  const formData = await req.formData()
+  const data = Object.fromEntries(formData.entries())
+  const parsed = bodySchema.safeParse(data)
+  if (!parsed.success) {
+    return error('invalid', 400)
+  }
+
+  const displayName = parsed.data.displayName?.trim() || null
+  const avatarUrl = parsed.data.avatarUrl?.trim() || null
+
+  await prisma.profile.upsert({
+    where: { userId: session.user.id },
+    update: { displayName, avatarUrl },
+    create: { userId: session.user.id, displayName, avatarUrl },
+  })
+
+  return NextResponse.redirect(new URL('/profile', req.url))
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { redirect } from 'next/navigation'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    redirect('/api/auth/signin')
+  }
+
+  const profile = await prisma.profile.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Profile</h1>
+      <form action="/api/profile" method="POST" className="space-y-4">
+        <div>
+          <label htmlFor="displayName" className="mb-1 block">
+            Display Name
+          </label>
+          <input
+            id="displayName"
+            name="displayName"
+            type="text"
+            defaultValue={profile?.displayName ?? ''}
+            className="w-full border p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="avatarUrl" className="mb-1 block">
+            Avatar URL
+          </label>
+          <input
+            id="avatarUrl"
+            name="avatarUrl"
+            type="text"
+            defaultValue={profile?.avatarUrl ?? ''}
+            className="w-full border p-2"
+          />
+        </div>
+        <button type="submit" className="bg-blue-500 px-4 py-2 text-white">
+          Save
+        </button>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add profile page that loads the session and shows a form for display name and avatar
- implement POST /api/profile endpoint with Zod validation and Prisma upsert

## Testing
- `pnpm exec eslint src/app/profile/page.tsx src/app/api/profile/route.ts`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: No test suite found in src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2eeaab48328b159da9b71ce4787