### PR TITLE
Refine leaderboard API return and test cases

### DIFF
--- a/src/app/api/leaderboard/route.test.ts
+++ b/src/app/api/leaderboard/route.test.ts
@@ -13,18 +13,18 @@ import { prisma } from '@/lib/prisma'
 
 describe('leaderboard API', () => {
   it('returns leaderboard entries', async () => {
-    const sample = [
+    const result = [
       { id: '1', elo: 1000, user: { id: 'u1', name: 'Alice' } },
       { id: '2', elo: 900, user: { id: 'u2', name: 'Bob' } },
     ]
 
-    prisma.leaderboard.findMany.mockResolvedValue(sample)
+    prisma.leaderboard.findMany.mockResolvedValue(result)
 
     const res = await GET()
     const json = await res.json()
 
     expect(res.status).toBe(200)
-    expect(json).toEqual(sample)
+    expect(json).toEqual(result)
     expect(prisma.leaderboard.findMany).toHaveBeenCalledWith(
       leaderboardQueryOptions,
     )

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -9,10 +9,8 @@ export const leaderboardQueryOptions = {
 
 export async function GET() {
   try {
-    const leaderboard = await prisma.leaderboard.findMany(
-      leaderboardQueryOptions,
-    )
-    return ok(leaderboard)
+    const result = await prisma.leaderboard.findMany(leaderboardQueryOptions)
+    return ok(result)
   } catch {
     return error('server error', 500)
   }


### PR DESCRIPTION
## Summary
- use `prisma.leaderboard.findMany` inside `GET` and return `ok(result)` with error fallback
- test leaderboard API for successful result and server error

## Testing
- `pnpm test src/app/api/leaderboard/route.test.ts`
- `pnpm lint` *(fails: Couldn’t find any `pages` or `app` directory; ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2ed5c2083289bccf488cd98132a