### PR TITLE
Add CI environment configuration

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,10 @@
+DATABASE_URL=postgres://user:password@localhost:5432/db
+NEXTAUTH_URL=http://localhost:3000
+EMAIL_SERVER=smtp://user:pass@smtp.localhost:587
+EMAIL_FROM=test@example.com
+GITHUB_ID=github-id
+GITHUB_SECRET=github-secret
+AUTH_SECRET=auth-secret
+UPSTASH_REDIS_URL=https://localhost:6379
+UPSTASH_REDIS_TOKEN=redis-token
+MATCHMAKING_QUEUE_TTL_SECONDS=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: npx prisma generate
-      - run: pnpm lint
-      - run: pnpm typecheck
-      - run: pnpm test
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm e2e --browser=chromium
+      - run: env $(cat .env.ci | xargs) pnpm lint
+      - run: env $(cat .env.ci | xargs) pnpm typecheck
+      - run: env $(cat .env.ci | xargs) pnpm test
+      - run: env $(cat .env.ci | xargs) pnpm exec playwright install --with-deps chromium
+      - run: env $(cat .env.ci | xargs) pnpm e2e --browser=chromium

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.ci
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
+### CI environment file
+
+The repository includes a `.env.ci` file with placeholder values for the required
+environment variables. CI workflows load this file when running lint, typecheck,
+unit tests, and Playwright checks. To replicate the CI setup locally, prefix
+commands with the variables from this file:
+
+```bash
+env $(cat .env.ci | xargs) pnpm lint
+```
+
+Use the same pattern for `pnpm typecheck`, `pnpm test`, and other CI tasks.
+
 ## Architecture Overview
 
 ```mermaid


### PR DESCRIPTION
## Summary
- add `.env.ci` with placeholders for required runtime variables
- load `.env.ci` in CI workflow for lint, typecheck, unit and e2e tests
- document CI env file usage for contributors

## Testing
- `pnpm install`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: 403 Forbidden fetching engine file)*
- `env $(cat .env.ci | xargs) pnpm lint` *(fails: ESLint errors in tests and components)*
- `env $(cat .env.ci | xargs) pnpm typecheck` *(fails: cannot find type definition file for '@prisma/client')*
- `env $(cat .env.ci | xargs) pnpm test` *(fails: No test suite found in src/lib/leaderboard.test.ts)*
- `env $(cat .env.ci | xargs) pnpm exec playwright install --with-deps chromium`
- `env $(cat .env.ci | xargs) pnpm e2e --browser=chromium` *(fails: multiple e2e tests did not pass)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1fbc2908328a846aa70d6109f25