### PR TITLE
Add CI env file and load variables in workflow

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,14 @@
+NEXT_PUBLIC_POSTHOG_KEY=pk_test
+NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+NEXT_PUBLIC_SUPABASE_URL=https://sb.example.com
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-key
+DATABASE_URL=postgresql://user:password@localhost:5432/db
+NEXTAUTH_URL=http://localhost:3000
+EMAIL_SERVER=smtp://user:password@smtp.example.com:587
+EMAIL_FROM=ci@example.com
+GITHUB_ID=github-id
+GITHUB_SECRET=github-secret
+AUTH_SECRET=auth-secret
+UPSTASH_REDIS_URL=https://example.upstash.io
+UPSTASH_REDIS_TOKEN=upstash-token
+MATCHMAKING_QUEUE_TTL_SECONDS=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install
+      - name: Load CI env
+        run: cat .env.ci >> $GITHUB_ENV
       - run: npx prisma generate
       - run: pnpm lint
       - run: pnpm typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.ci
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
+### CI environment
+
+The GitHub Actions workflow loads environment variables from `.env.ci` before
+running linting, type checking, unit, and end-to-end tests. The file contains
+safe placeholder values so contributors can run CI checks without real secrets.
+
 ## Architecture Overview
 
 ```mermaid


### PR DESCRIPTION
## Summary
- add `.env.ci` with placeholder values for all runtime environment variables
- load `.env.ci` in CI workflow so lint, typecheck, unit and e2e tests have required env
- document CI environment usage for contributors

## Testing
- `npx prisma generate` *(fails: 403 Forbidden fetching Prisma engine)*
- `pnpm lint` *(fails: Unexpected var/any in tests and components)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: No test suite found in src/lib/leaderboard.test.ts)*
- `pnpm exec playwright install --with-deps chromium` *(fails: server returned code 403 fetching browser)*
- `pnpm e2e --browser=chromium` *(fails: Executable doesn't exist for chromium)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2eab6288328a7298cf0153848d6