### PR TITLE
feat: add profile page and API route

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { error } from '@/lib/api-response'
+
+const bodySchema = z.object({
+  displayName: z.string().min(1).max(100).optional(),
+  avatarUrl: z.string().url().optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/api/auth/signin', req.url))
+  }
+  const formData = await req.formData()
+  const data = {
+    displayName: formData.get('displayName')?.toString().trim() || undefined,
+    avatarUrl: formData.get('avatarUrl')?.toString().trim() || undefined,
+  }
+  const parsed = bodySchema.safeParse(data)
+  if (!parsed.success) {
+    return error('invalid', 400)
+  }
+
+  await prisma.profile.upsert({
+    where: { userId: session.user.id },
+    update: parsed.data,
+    create: { userId: session.user.id, ...parsed.data },
+  })
+
+  return NextResponse.redirect(new URL('/profile', req.url))
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { redirect } from 'next/navigation'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    redirect('/api/auth/signin')
+  }
+
+  const profile = await prisma.profile.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Profile</h1>
+      <form
+        action="/api/profile"
+        method="post"
+        className="flex flex-col gap-4 max-w-md"
+      >
+        <label className="flex flex-col">
+          <span className="mb-1">Display Name</span>
+          <input
+            type="text"
+            name="displayName"
+            defaultValue={profile?.displayName ?? ''}
+            className="border px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="mb-1">Avatar URL</span>
+          <input
+            type="url"
+            name="avatarUrl"
+            defaultValue={profile?.avatarUrl ?? ''}
+            className="border px-2 py-1"
+          />
+        </label>
+        <button type="submit" className="px-4 py-2 text-white bg-blue-600">
+          Save
+        </button>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add profile page that loads current user and renders profile form
- implement profile API route with zod validation and Prisma upsert

## Testing
- `pnpm lint` *(fails: Unexpected var in GameCanvas.test.tsx)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: No test suite found in file src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cf45a747c83288ee04317f7fffa9d