### PR TITLE
Load CI env variables for tests

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,14 @@
+NEXT_PUBLIC_POSTHOG_KEY=placeholder
+NEXT_PUBLIC_POSTHOG_HOST=https://example.com
+NEXT_PUBLIC_SUPABASE_URL=https://example.com
+NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder
+DATABASE_URL=postgresql://user:password@localhost:5432/db
+NEXTAUTH_URL=http://localhost:3000
+EMAIL_SERVER=smtp://user:pass@localhost:587
+EMAIL_FROM=dev@example.com
+GITHUB_ID=placeholder
+GITHUB_SECRET=placeholder
+AUTH_SECRET=placeholder
+UPSTASH_REDIS_URL=https://example.com/redis
+UPSTASH_REDIS_TOKEN=placeholder
+MATCHMAKING_QUEUE_TTL_SECONDS=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: npx prisma generate
+      - name: Load CI env
+        run: cat .env.ci >> $GITHUB_ENV
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.ci
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
+### CI environment
+
+`.env.ci` provides safe placeholder values for all required environment variables. Load it to mirror the CI setup when running checks locally:
+
+```bash
+source .env.ci
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm e2e --browser=chromium
+```
+
 ## Architecture Overview
 
 ```mermaid

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from '@playwright/test'
 
+const withEnv = (cmd: string) => `bash -ac "set -a; source .env.ci; ${cmd}"`
+
 export default defineConfig({
   webServer: {
-    command: 'pnpm dev',
+    command: withEnv('pnpm dev'),
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Summary
- add `.env.ci` with placeholder variables used in tests
- load `.env.ci` in CI workflow steps and Playwright config
- document how to reuse CI env locally

## Testing
- `pnpm lint` *(fails: unexpected var/any in tests)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: No test suite found)*
- `pnpm exec playwright install --with-deps chromium`
- `pnpm e2e --browser=chromium` *(fails: ssr: false not allowed with next/dynamic)*

------
https://chatgpt.com/codex/tasks/task_e_689cf59488dc8328b19bbc8d14e86381