### PR TITLE
refactor: deduplicate vitest resolve config

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1,0 +1,18 @@
+import { vi, describe, it, expect } from 'vitest'
+
+// Mock redis to avoid real network calls and to verify publish is invoked correctly
+vi.mock('@/lib/redis', () => ({
+  redis: {
+    publish: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { triggerLeaderboardRecalculation } from '@/lib/leaderboard'
+import { redis } from '@/lib/redis'
+
+describe('triggerLeaderboardRecalculation', () => {
+  it('publishes a leaderboard recalculation event', async () => {
+    await triggerLeaderboardRecalculation()
+    expect(redis.publish).toHaveBeenCalledWith('leaderboard:recalc', '')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,4 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**'],
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- remove duplicate resolve block in vitest config so '@' aliases to src once
- add missing leaderboard recalculation test and mock redis

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf59b90408328affec5a034386d76