### PR TITLE
fix: remove duplicate resolve block from vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,4 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**'],
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
 })


### PR DESCRIPTION
## Summary
- remove second resolve block from `vitest.config.ts`

## Testing
- `pnpm test` *(fails: Error: No test suite found in file /workspace/pong/src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d3f49f1f48328ad3be506d46b7621