### PR TITLE
Add CI env configuration and document usage

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,14 @@
+NEXT_PUBLIC_POSTHOG_KEY=posthog_key
+NEXT_PUBLIC_POSTHOG_HOST=https://posthog.example
+NEXT_PUBLIC_SUPABASE_URL=https://supabase.example
+NEXT_PUBLIC_SUPABASE_ANON_KEY=supabase_anon_key
+DATABASE_URL=postgresql://user:password@localhost:5432/db
+NEXTAUTH_URL=http://localhost:3000
+EMAIL_SERVER=smtp://user:pass@example.com:587
+EMAIL_FROM=no-reply@example.com
+GITHUB_ID=github_id
+GITHUB_SECRET=github_secret
+AUTH_SECRET=auth_secret
+UPSTASH_REDIS_URL=https://redis.example.com
+UPSTASH_REDIS_TOKEN=redis_token
+MATCHMAKING_QUEUE_TTL_SECONDS=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: npx prisma generate
+      - name: Load CI env vars
+        run: cat .env.ci >> $GITHUB_ENV
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.ci
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
+### Reproducing CI locally
+
+The repository includes a `.env.ci` file with safe placeholder values for all
+required environment variables. GitHub Actions and Playwright load this file
+automatically. To mimic the CI environment locally, source the file before
+running lint, type checks, tests, or Playwright:
+
+```bash
+set -a
+source .env.ci
+set +a
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm e2e --browser=chromium
+```
+
 ## Architecture Overview
 
 ```mermaid

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   webServer: {
-    command: 'pnpm dev',
+    command: 'bash -c "set -a && source .env.ci && set +a && pnpm dev"',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Summary
- add `.env.ci` with placeholder values for all parsed environment variables
- load `.env.ci` in GitHub Actions workflow before lint, typecheck, test, and e2e steps
- source `.env.ci` when starting Playwright’s dev server
- document how to reproduce the CI environment locally

## Testing
- `pnpm lint` *(fails: Unexpected var and any rules)*
- `npx prisma generate` *(fails: 403 downloading Prisma engine)*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(fails: no test suite found in src/lib/leaderboard.test.ts)*
- `pnpm exec playwright install --with-deps chromium`
- `pnpm e2e --browser=chromium` *(fails: page error and 3 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d3f48d3748328a64809a64eaa6955