### PR TITLE
Add profile editing page and API endpoint

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { NextResponse } from 'next/server'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { error } from '@/lib/api-response'
+
+const bodySchema = z.object({
+  displayName: z.string().max(100).optional(),
+  avatarUrl: z.string().url().optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/api/auth/signin', req.url))
+  }
+
+  const formData = await req.formData()
+  const data = {
+    displayName: formData.get('displayName')?.toString().trim() || undefined,
+    avatarUrl: formData.get('avatarUrl')?.toString().trim() || undefined,
+  }
+  const parsed = bodySchema.safeParse(data)
+  if (!parsed.success) {
+    return error('invalid', 400)
+  }
+
+  await prisma.profile.upsert({
+    where: { userId: session.user.id },
+    create: { userId: session.user.id, ...parsed.data },
+    update: parsed.data,
+  })
+
+  return NextResponse.redirect(new URL('/profile', req.url))
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { redirect } from 'next/navigation'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    redirect('/api/auth/signin')
+  }
+  const profile = await prisma.profile.findUnique({
+    where: { userId: session.user.id },
+  })
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Profile</h1>
+      <form
+        action="/api/profile"
+        method="post"
+        className="flex flex-col gap-4 max-w-md"
+      >
+        <label className="flex flex-col">
+          <span className="mb-1">Display Name</span>
+          <input
+            type="text"
+            name="displayName"
+            defaultValue={profile?.displayName ?? ''}
+            className="border p-2"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="mb-1">Avatar URL</span>
+          <input
+            type="url"
+            name="avatarUrl"
+            defaultValue={profile?.avatarUrl ?? ''}
+            className="border p-2"
+          />
+        </label>
+        <button
+          type="submit"
+          className="px-4 py-2 text-white bg-blue-500 rounded"
+        >
+          Save
+        </button>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add profile form page showing user profile
- add API route to validate and upsert profile data and redirect accordingly

## Testing
- `pnpm lint` (fails: Unexpected var, type errors)
- `pnpm test` (fails: No test suite found in file)

------
https://chatgpt.com/codex/tasks/task_e_689d3f4b1e5c8328b1ddd63d07370ca2