### PR TITLE
feat: add history page

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { redirect } from 'next/navigation'
 
 import { getServerAuthSession } from '@/lib/auth'
@@ -6,74 +5,58 @@ import { prisma } from '@/lib/prisma'
 
 export default async function HistoryPage() {
   const session = await getServerAuthSession()
-  if (!session?.user) {
+  const user = session?.user
+  if (!user) {
     redirect('/api/auth/signin')
   }
 
-  const userId = session.user.id
+  const matches = await prisma.match.findMany({
+    where: { OR: [{ p1Id: user!.id }, { p2Id: user!.id }] },
+    orderBy: { startedAt: 'desc' },
+    include: {
+      p1: { select: { name: true } },
+      p2: { select: { name: true } },
+      winner: { select: { id: true, name: true } },
+    },
+  })
 
-  try {
-    const matches = await prisma.match.findMany({
-      where: {
-        OR: [{ p1Id: userId }, { p2Id: userId }],
-      },
-      orderBy: { startedAt: 'desc' },
-      include: {
-        p1: { select: { name: true } },
-        p2: { select: { name: true } },
-        winner: { select: { id: true, name: true } },
-      },
-    })
-
-    return (
-      <main className="p-8">
-        <h1 className="mb-4 text-3xl font-bold">Match History</h1>
-        <table className="min-w-full border">
-          <thead>
-            <tr>
-              <th className="px-4 py-2 text-left border-b">Opponent</th>
-              <th className="px-4 py-2 text-left border-b">Score</th>
-              <th className="px-4 py-2 text-left border-b">Date</th>
-              <th className="px-4 py-2 text-left border-b">Winner</th>
-            </tr>
-          </thead>
-          <tbody>
-            {matches.map((match) => {
-              const isP1 = match.p1Id === userId
-              const opponentName = isP1
-                ? (match.p2?.name ?? 'Unknown')
-                : (match.p1.name ?? 'Unknown')
-              const userScore = isP1 ? match.p1Score : match.p2Score
-              const opponentScore = isP1 ? match.p2Score : match.p1Score
-              const winner = match.winnerId
-                ? match.winnerId === userId
-                  ? 'You'
-                  : (match.winner?.name ?? 'Unknown')
-                : 'TBD'
-              return (
-                <tr key={match.id}>
-                  <td className="px-4 py-2 border-b">{opponentName}</td>
-                  <td className="px-4 py-2 border-b">
-                    {userScore} - {opponentScore}
-                  </td>
-                  <td className="px-4 py-2 border-b">
-                    {match.startedAt.toLocaleString()}
-                  </td>
-                  <td className="px-4 py-2 border-b">{winner}</td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      </main>
-    )
-  } catch (error) {
-    console.error('Failed to load match history:', error)
-    return (
-      <main className="p-8">
-        <h1 className="mb-4 text-3xl font-bold">Match History</h1>
-        <p>Unable to load match history.</p>
-      </main>
-    )
-  }
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-3xl font-bold">Match History</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left border-b">Opponent</th>
+            <th className="px-4 py-2 text-left border-b">Score</th>
+            <th className="px-4 py-2 text-left border-b">Date</th>
+            <th className="px-4 py-2 text-left border-b">Winner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {matches.map((match) => {
+            const isP1 = match.p1Id === user!.id
+            const opponent = isP1 ? match.p2?.name : match.p1.name
+            const userScore = isP1 ? match.p1Score : match.p2Score
+            const opponentScore = isP1 ? match.p2Score : match.p1Score
+            const winner =
+              match.winnerId === user!.id
+                ? 'You'
+                : (match.winner?.name ?? 'TBD')
+            return (
+              <tr key={match.id}>
+                <td className="px-4 py-2 border-b">{opponent ?? 'Unknown'}</td>
+                <td className="px-4 py-2 border-b">
+                  {userScore} - {opponentScore}
+                </td>
+                <td className="px-4 py-2 border-b">
+                  {new Date(match.startedAt).toLocaleString()}
+                </td>
+                <td className="px-4 py-2 border-b">{winner}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- implement match history page querying user matches and showing opponent, score, date, and winner

## Testing
- `pnpm lint` *(fails: Unexpected var, no-explicit-any)*
- `pnpm test` *(fails: No test suite found in src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d3f4ba588832898df99e2a425bc83