### PR TITLE
Add EditorConfig and document support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ pnpm dev
 
 Copy `.env.example` to `.env.local` and fill in secrets.
 
+This project includes an [EditorConfig](https://editorconfig.org/) file to enforce
+2-space indentation, UTF-8 encoding, and final newlines.
+
 ### Environment variables
 
 Set the following environment variables for the application:
@@ -34,12 +37,12 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
-
 pnpm lint
 pnpm typecheck
 pnpm test
 pnpm e2e --browser=chromium
-```
+
+````
 
 ## Architecture Overview
 
@@ -52,7 +55,7 @@ graph LR
   A -->|HTTP| C[Next.js API Routes]
   C --> D[(Postgres)]
   C --> E[(Upstash Redis)]
-```
+````
 
 ## Background jobs
 


### PR DESCRIPTION
## Summary
- add `.editorconfig` enforcing UTF-8, 2-space indent and final newlines
- note EditorConfig usage in documentation

## Testing
- `pnpm lint` *(fails: Unexpected any in tests and parse errors)*
- `pnpm test` *(fails: transform error in src/lib/leaderboard.test.ts)*
- `pnpm typecheck` *(fails: TS1128 in src/lib/leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d84c5a4008328ba5929a147fe3acf