### PR TITLE
Add docker-compose for Postgres and Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Modern Pong built with Next.js, Phaser 3, and a serverless stack.
 
 ## Setup
 
+Start Postgres and Redis locally:
+
 ```bash
+docker-compose up -d
 pnpm install
 pnpm prisma migrate dev
 pnpm dev
@@ -34,12 +37,12 @@ Optional variables:
 
 Use these names when setting deployment secrets.
 
-
 pnpm lint
 pnpm typecheck
 pnpm test
 pnpm e2e --browser=chromium
-```
+
+````
 
 ## Architecture Overview
 
@@ -52,7 +55,7 @@ graph LR
   A -->|HTTP| C[Next.js API Routes]
   C --> D[(Postgres)]
   C --> E[(Upstash Redis)]
-```
+````
 
 ## Background jobs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add Docker Compose file with Postgres and Redis services
- document starting local dependencies via `docker-compose up`

## Testing
- `pnpm lint` *(fails: Unexpected any, parse error in tests)*
- `pnpm typecheck` *(fails: parse error in tests)*
- `pnpm test` *(fails: unexpected "}" in leaderboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d84c787808328b105f7be3f5ac015