### PR TITLE
ci: cancel previous runs per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure CI cancels in-progress runs for the same branch using workflow concurrency

## Testing
- `pnpm lint` *(fails: Unexpected any. Specify a different type.)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d71ee70a083288301eb91c9023d1e