### PR TITLE
Add auth and matchmaking e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: npx prisma generate
-
-        run: cat .env.ci >> $GITHUB_ENV
+      - run: cat .env.ci >> $GITHUB_ENV
+      - run: pnpm prisma:seed
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { PrismaClient } from '@prisma/client'
+import { execSync } from 'node:child_process'
+
+const prisma = new PrismaClient()
+
+async function createVerificationToken(email: string, token: string) {
+  const expires = new Date(Date.now() + 60 * 60 * 1000)
+  await prisma.$executeRaw`INSERT INTO "VerificationToken" ("identifier","token","expires") VALUES (${email}, ${token}, ${expires})`
+}
+
+test.beforeAll(async () => {
+  execSync('pnpm prisma:seed', { stdio: 'inherit' })
+})
+
+test.afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+test('user can sign in, view profile and sign out', async ({ page }) => {
+  const email = 'alice@example.com'
+  const token = 'e2e-token-' + Date.now()
+  await createVerificationToken(email, token)
+
+  await page.goto(
+    `http://localhost:3000/api/auth/callback/email?token=${token}&email=${email}`,
+  )
+  await page.goto('http://localhost:3000')
+  await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible()
+
+  await page.goto('http://localhost:3000/profile')
+  await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Sign out' }).click()
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+})

--- a/e2e/matchmaking.spec.ts
+++ b/e2e/matchmaking.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+import { PrismaClient } from '@prisma/client'
+import { execSync } from 'node:child_process'
+
+const prisma = new PrismaClient()
+
+async function signIn(page, email: string) {
+  const token = 'e2e-token-' + Math.random().toString(36).slice(2)
+  const expires = new Date(Date.now() + 60 * 60 * 1000)
+  await prisma.$executeRaw`INSERT INTO "VerificationToken" ("identifier","token","expires") VALUES (${email}, ${token}, ${expires})`
+  await page.goto(
+    `http://localhost:3000/api/auth/callback/email?token=${token}&email=${email}`,
+  )
+}
+
+test.beforeAll(async () => {
+  execSync('pnpm prisma:seed', { stdio: 'inherit' })
+})
+
+test.afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+test('two players can match and start a game', async ({ browser }) => {
+  const context1 = await browser.newContext()
+  const context2 = await browser.newContext()
+  const page1 = await context1.newPage()
+  const page2 = await context2.newPage()
+
+  await signIn(page1, 'alice@example.com')
+  await signIn(page2, 'bob@example.com')
+
+  await page1.goto('http://localhost:3000/play')
+  await page2.goto('http://localhost:3000/play')
+
+  await page1.getByRole('button', { name: 'Play Online' }).click()
+  await page2.getByRole('button', { name: 'Play Online' }).click()
+
+  await expect(page1).toHaveURL(/\/match\//)
+  const matchUrl = page1.url()
+  await expect(page2).toHaveURL(matchUrl)
+
+  await context1.close()
+  await context2.close()
+})


### PR DESCRIPTION
## Summary
- test sign-in, sign-out, and profile view
- simulate two authenticated players queuing and joining a match
- seed test users in CI before running e2e tests

## Testing
- `pnpm lint` *(fails: Unexpected any / parsing errors)*
- `pnpm test` *(fails: src/lib/leaderboard.test.ts parse error)*
- `pnpm e2e --browser=chromium` *(fails: TypeError: The "file" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_689d7bcee820832887e39caa72433a22