### PR TITLE
Add friendly error and not-found pages with tests

### DIFF
--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Error from './error'
+
+describe('Error page', () => {
+  it('renders message and home link', () => {
+    render(<Error />)
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /go home/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+
+export default function Error() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-3xl font-bold">Something went wrong</h1>
+      <Link href="/" className="text-blue-500 underline">
+        Go home
+      </Link>
+    </main>
+  )
+}

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import NotFound from './not-found'
+
+describe('NotFound page', () => {
+  it('renders message and home link', () => {
+    render(<NotFound />)
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /go home/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-3xl font-bold">Page not found</h1>
+      <Link href="/" className="text-blue-500 underline">
+        Go home
+      </Link>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add basic `error.tsx` error boundary page with link back home
- add simple `not-found.tsx` page for unknown routes
- cover new pages with React Testing Library tests

## Testing
- `pnpm lint` *(fails: Unexpected any & parse errors in existing files)*
- `pnpm test` *(fails: src/lib/leaderboard.test.ts transform error)*

------
https://chatgpt.com/codex/tasks/task_e_689d7bcdb62c83288e318e20aeddc79e