### PR TITLE
test: add profile API route tests

### DIFF
--- a/src/app/api/profile/route.test.ts
+++ b/src/app/api/profile/route.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from './route'
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+vi.mock('@/lib/auth', () => ({
+  getServerAuthSession: vi.fn(),
+}))
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    profile: {
+      upsert: vi.fn(),
+    },
+  },
+}))
+
+describe('POST /api/profile', () => {
+  const session = { user: { id: 'user-id' } }
+
+  it('updates profile with valid data', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(session)
+    const form = new FormData()
+    form.set('displayName', 'Alice')
+    form.set('avatarUrl', 'https://example.com/avatar.png')
+    const req = new Request('http://localhost/api/profile', {
+      method: 'POST',
+      body: form,
+    })
+
+    const res = await POST(req)
+
+    expect(prisma.profile.upsert).toHaveBeenCalledWith({
+      where: { userId: session.user.id },
+      create: {
+        userId: session.user.id,
+        displayName: 'Alice',
+        avatarUrl: 'https://example.com/avatar.png',
+      },
+      update: {
+        displayName: 'Alice',
+        avatarUrl: 'https://example.com/avatar.png',
+      },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost/profile')
+  })
+
+  it('redirects unauthenticated users', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+    const req = new Request('http://localhost/api/profile', {
+      method: 'POST',
+      body: new FormData(),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost/api/auth/signin')
+    expect(prisma.profile.upsert).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid fields', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(session)
+    const form = new FormData()
+    form.set('avatarUrl', 'invalid-url')
+    const req = new Request('http://localhost/api/profile', {
+      method: 'POST',
+      body: form,
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    expect(prisma.profile.upsert).not.toHaveBeenCalled()
+  })
+})
+

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -13,7 +13,7 @@ const bodySchema = z.object({
 export async function POST(req: Request) {
   const session = await getServerAuthSession()
   if (!session?.user) {
-    return NextResponse.redirect(new URL('/api/auth/signin', req.url))
+    return NextResponse.redirect(new URL('/api/auth/signin', req.url), 302)
   }
 
   const formData = await req.formData()
@@ -32,5 +32,5 @@ export async function POST(req: Request) {
     update: parsed.data,
   })
 
-  return NextResponse.redirect(new URL('/profile', req.url))
+  return NextResponse.redirect(new URL('/profile', req.url), 302)
 }


### PR DESCRIPTION
## Summary
- add unit tests for profile API updates and validation
- ensure profile API redirects use HTTP 302 status

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc7cfe9bc8328af4734fe146e47a8