### PR TITLE
Handle telemetry query errors

### DIFF
--- a/src/app/api/telemetry/route.get.test.ts
+++ b/src/app/api/telemetry/route.get.test.ts
@@ -59,4 +59,16 @@ describe('telemetry GET API', () => {
     expect(await res.json()).toEqual({ error: 'invalid since' })
     expect(prisma.telemetry.findMany).not.toHaveBeenCalled()
   })
+
+  it('returns 500 when prisma.findMany throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    prisma.telemetry.findMany.mockRejectedValueOnce(new Error('fail'))
+
+    const res = await GET(new Request('http://localhost/api/telemetry'))
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'server error' })
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
 })

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -67,11 +67,17 @@ export async function GET(req: Request) {
     where.createdAt = { gte: date }
   }
 
-  const data = await prisma.telemetry.findMany({
-    where,
-    orderBy: { createdAt: 'desc' },
-    take: 100,
-  })
-
-  return ok(data)
+  try {
+    const data = await prisma.telemetry.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    })
+    return ok(data)
+  } catch (err) {
+    console.warn('telemetry query failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return error('server error', 500)
+  }
 }


### PR DESCRIPTION
## Summary
- handle `prisma.telemetry.findMany` errors with logging and `server error`
- add test covering `GET /api/telemetry` query failures

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc7cec50483289a5fd72a5581c1da