### PR TITLE
Add Redis expiration for matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Optional variables:
 - `NEXT_PUBLIC_POSTHOG_KEY` – PostHog client key
 - `NEXT_PUBLIC_POSTHOG_HOST` – PostHog host URL
 - `MATCHMAKING_QUEUE_TTL_SECONDS` – TTL in seconds for the matchmaking queue (default 60)
+- `MATCH_TTL_SECONDS` – TTL in seconds for stored match details (default 3600)
 
 Use these names when setting deployment secrets.
 

--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -58,6 +58,7 @@ describe('matchmaking API', () => {
     expect(redis.set).toHaveBeenCalledWith(
       'match:m1',
       JSON.stringify({ p1: 'u1', p2: 'u2' }),
+      { ex: 3600 },
     )
   })
 

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -42,6 +42,7 @@ export async function POST(req: Request) {
     await redis.set(
       `match:${match.id}`,
       JSON.stringify({ p1: opponent, p2: userId }),
+      { ex: env.MATCH_TTL_SECONDS },
     )
     return ok({ p1: opponent, p2: userId, matchId: match.id })
   } catch {

--- a/src/app/api/score/route.test.ts
+++ b/src/app/api/score/route.test.ts
@@ -10,7 +10,14 @@ vi.mock('../../../lib/prisma', () => ({
 }))
 
 vi.mock('../../../lib/auth', () => ({
+  getServerAuthSession: vi.fn(),
+}))
 
+vi.mock('../../../lib/leaderboard', () => ({
+  triggerLeaderboardRecalculation: vi.fn(),
+}))
+
+import { POST } from './route'
 import { prisma } from '../../../lib/prisma'
 import { getServerAuthSession } from '../../../lib/auth'
 import { triggerLeaderboardRecalculation } from '../../../lib/leaderboard'

--- a/src/lib/env.server.ts
+++ b/src/lib/env.server.ts
@@ -15,6 +15,7 @@ const envSchema = z.object({
   UPSTASH_REDIS_URL: z.string().url(),
   UPSTASH_REDIS_TOKEN: z.string(),
   MATCHMAKING_QUEUE_TTL_SECONDS: z.coerce.number().int().positive().default(60),
+  MATCH_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
 })
 
 const parsed = envSchema.safeParse(process.env)

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -33,6 +33,7 @@ describe('env validation', () => {
     expect(env.DATABASE_URL).toBe(baseEnv.DATABASE_URL)
     expect(env.NEXTAUTH_URL).toBe(baseEnv.NEXTAUTH_URL)
     expect(env.MATCHMAKING_QUEUE_TTL_SECONDS).toBe(60)
+    expect(env.MATCH_TTL_SECONDS).toBe(3600)
   })
 
   it('throws when required env var is missing', async () => {
@@ -50,6 +51,11 @@ describe('env validation', () => {
     await expect(import('./env.server')).rejects.toThrow(
       /MATCHMAKING_QUEUE_TTL_SECONDS/,
     )
+  })
+
+  it('throws when MATCH_TTL_SECONDS is invalid', async () => {
+    process.env.MATCH_TTL_SECONDS = 'abc'
+    await expect(import('./env.server')).rejects.toThrow(/MATCH_TTL_SECONDS/)
   })
 
   it('throws when DATABASE_URL is missing', async () => {


### PR DESCRIPTION
## Summary
- expire match keys in Redis
- configure match key TTL via `MATCH_TTL_SECONDS`
- test TTL handling and fix broken score route test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e6b95b70832894647cfd511f2d2f