### PR TITLE
refactor: reuse GameCanvas for match page

### DIFF
--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -1,31 +1,11 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import { useSettings } from '@/store/settings'
-import { usePhaserGame } from '@/hooks/usePhaserGame'
+import { GameCanvas } from '@/components/GameCanvas'
 
 export default function MatchPage({ params }: { params: { id: string } }) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const muted = useSettings((s) => s.muted)
-  const gameRef = usePhaserGame(containerRef, muted, params.id)
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (!containerRef.current || !gameRef.current) return
-      gameRef.current.scale.resize(
-        containerRef.current.clientWidth,
-        containerRef.current.clientHeight,
-      )
-    }
-    window.addEventListener('resize', handleResize)
-    return () => {
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [gameRef])
-
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-8">
-      <div ref={containerRef} className="w-full h-full" />
+      <GameCanvas matchId={params.id} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- swap manual Phaser setup for GameCanvas component on match page

## Testing
- `pnpm lint` *(fails: Parsing error in src/app/api/score/route.test.ts)*
- `pnpm typecheck` *(fails: ':' expected in src/app/api/score/route.test.ts)*
- `pnpm test` *(fails: transform failed with 'Expected ":" but found "{" in src/app/api/score/route.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a2e6b8ff248328b468a458b6bd7e5a