### PR TITLE
feat: display streak on leaderboard

### DIFF
--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -5,5 +5,6 @@ test('leaderboard page lists players', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
   await expect(page.getByRole('columnheader', { name: 'Wins' })).toBeVisible()
   await expect(page.getByRole('columnheader', { name: 'Losses' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Streak' })).toBeVisible()
   await expect(page.getByRole('row').nth(1)).toBeVisible()
 })

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,11 +1,12 @@
 import { prisma } from '@/lib/prisma'
 import { ok, error } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
 
 export const leaderboardQueryOptions = {
   take: 10,
   orderBy: { elo: 'desc' },
   include: { user: true },
-} as const
+} satisfies Prisma.LeaderboardFindManyArgs
 
 export async function GET() {
   try {

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -7,6 +7,7 @@ interface LeaderboardEntry {
   elo: number
   wins: number
   losses: number
+  streak: number
   user: {
     name: string | null
   } | null
@@ -28,6 +29,7 @@ export default async function LeaderboardPage() {
               <th className="px-4 py-2 text-left border-b">ELO</th>
               <th className="px-4 py-2 text-left border-b">Wins</th>
               <th className="px-4 py-2 text-left border-b">Losses</th>
+              <th className="px-4 py-2 text-left border-b">Streak</th>
             </tr>
           </thead>
           <tbody>
@@ -39,6 +41,7 @@ export default async function LeaderboardPage() {
                 <td className="px-4 py-2 border-b">{entry.elo}</td>
                 <td className="px-4 py-2 border-b">{entry.wins}</td>
                 <td className="px-4 py-2 border-b">{entry.losses}</td>
+                <td className="px-4 py-2 border-b">{entry.streak}</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- show player streaks on the leaderboard table
- type leaderboard query options and include streak
- check for streak column in Playwright leaderboard test

## Testing
- `pnpm test` *(fails: Transform failed with 1 error: expected ":" but found "{")*
- `pnpm e2e` *(fails: The "file" argument must be of type string. Received undefined)*
- `pnpm lint` *(fails: Parsing error in src/app/api/score/route.test.ts: ':' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e8ab1114832886a493e79d3c58f0