### PR TITLE
Improve matchmaking error handling and backoff

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -6,8 +6,9 @@ import { useEffect, useRef, useState } from 'react'
 export default function PlayPage() {
   const router = useRouter()
   const [status, setStatus] = useState<
-    'idle' | 'searching' | 'timeout' | 'error'
+    'idle' | 'searching' | 'timeout' | 'error' | 'aborted'
   >('idle')
+  const [reason, setReason] = useState('')
   const controllerRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
@@ -23,8 +24,10 @@ export default function PlayPage() {
     controllerRef.current = controller
 
     setStatus('searching')
+    setReason('')
     const start = Date.now()
     const TIMEOUT_MS = 15000
+    let attempt = 0
     try {
       while (Date.now() - start < TIMEOUT_MS) {
         const res = await fetch('/api/matchmaking', {
@@ -33,6 +36,7 @@ export default function PlayPage() {
         })
         if (!res.ok) {
           setStatus('error')
+          setReason('Matchmaking error')
           return
         }
         const data = await res.json()
@@ -40,14 +44,25 @@ export default function PlayPage() {
           router.push(`/match/${data.matchId}`)
           return
         }
-        await new Promise((r) => setTimeout(r, 1000))
+        const delay = Math.min(1000 * 2 ** attempt, 8000)
+        attempt++
+        await new Promise((r) => setTimeout(r, delay))
       }
       setStatus('timeout')
-    } catch {
-      if (controller.signal.aborted) {
-        setStatus('idle')
+      setReason('No match found before timeout')
+    } catch (err) {
+      if (
+        controller.signal.aborted ||
+        (err instanceof DOMException && err.name === 'AbortError')
+      ) {
+        setStatus('aborted')
+        setReason('Matchmaking aborted')
+      } else if (err instanceof TypeError) {
+        setStatus('error')
+        setReason('Server unreachable')
       } else {
         setStatus('error')
+        setReason('Matchmaking error')
       }
     } finally {
       controller.abort()
@@ -73,7 +88,7 @@ export default function PlayPage() {
       {status === 'searching' && <p>Searching for an opponent...</p>}
       {status === 'timeout' && (
         <div className="flex flex-col items-center gap-2">
-          <p>Queue timed out.</p>
+          <p>{reason || 'Queue timed out.'}</p>
           <button
             className="px-4 py-2 bg-blue-500 text-white rounded"
             onClick={retry}
@@ -84,7 +99,18 @@ export default function PlayPage() {
       )}
       {status === 'error' && (
         <div className="flex flex-col items-center gap-2">
-          <p>Something went wrong.</p>
+          <p>{reason || 'Something went wrong.'}</p>
+          <button
+            className="px-4 py-2 bg-blue-500 text-white rounded"
+            onClick={retry}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {status === 'aborted' && (
+        <div className="flex flex-col items-center gap-2">
+          <p>{reason}</p>
           <button
             className="px-4 py-2 bg-blue-500 text-white rounded"
             onClick={retry}


### PR DESCRIPTION
## Summary
- show specific matchmaking errors like server unreachable or server-side failure
- use exponential backoff instead of constant 1s polling during matchmaking
- surface abort and timeout reasons in the UI

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_68a35b9e07808328a52351ee8f4a7f66