### PR TITLE
feat: handle supabase init errors

### DIFF
--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -93,6 +93,13 @@ export default class MainScene extends Phaser.Scene {
           this.lastRemoteUpdate = Date.now()
         })
       void this.channel.subscribe()
+    } else if (this.matchId && !supabase) {
+      this.add
+        .text(width / 2, height / 2, 'Supabase is unavailable', {
+          color: '#fff',
+          fontSize: '16px',
+        })
+        .setOrigin(0.5)
     }
 
     this.events.once(Phaser.Scenes.Events.DESTROY, () => {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,10 +1,20 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { env } from '@/lib/env.client'
 
-export const supabase: SupabaseClient | null =
-  env.NEXT_PUBLIC_SUPABASE_URL && env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    ? createClient(
-        env.NEXT_PUBLIC_SUPABASE_URL,
-        env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      )
-    : null
+let supabase: SupabaseClient | null = null
+
+if (env.NEXT_PUBLIC_SUPABASE_URL && env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+  try {
+    supabase = createClient(
+      env.NEXT_PUBLIC_SUPABASE_URL,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    )
+  } catch (error) {
+    console.warn('Failed to initialize Supabase client', error)
+    supabase = null
+  }
+} else {
+  console.warn('Supabase environment variables are missing or invalid')
+}
+
+export { supabase }


### PR DESCRIPTION
## Summary
- handle missing or invalid Supabase config with a warning
- show message when Supabase realtime can't connect

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35b9d9074832892f483f5f66c38ad