### PR TITLE
feat: improve offline caching

### DIFF
--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -20,3 +20,16 @@ test('game continues offline after service worker registration', async ({
   )
   expect(frame1).not.toBe(frame2)
 })
+
+test('offline navigation works after initial load', async ({ page }) => {
+  await page.goto('http://localhost:3000')
+  await page.waitForFunction(() => navigator.serviceWorker?.controller)
+
+  await page.context().setOffline(true)
+
+  await page.goto('http://localhost:3000/play')
+  await expect(page.locator('button', { hasText: 'Play Online' })).toBeVisible()
+
+  await page.goto('http://localhost:3000/match/1')
+  await expect(page.locator('canvas')).toBeVisible()
+})

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,40 @@
-const CACHE_NAME = 'photonpong-cache-v1'
-const ASSETS = ['/', '/favicon.ico']
+const CACHE_VERSION = 'v2'
+const CACHE_NAME = `photonpong-cache-${CACHE_VERSION}`
+const ASSETS = [
+  '/',
+  '/favicon.ico',
+  '/icon.svg',
+  '/locales/en.json',
+  '/locales/es.json',
+  '/_next/static/chunks/main-app.js',
+  '/_next/static/chunks/webpack.js',
+  '/_next/static/chunks/app/play/page.js',
+  '/_next/static/chunks/app/match/%5Bid%5D/page.js',
+]
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)))
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS))
+      .catch(() => undefined),
+  )
   self.skipWaiting()
 })
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim())
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  )
 })
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
## Summary
- extend service worker cache with static assets, images and locales
- version and clean caches on activation
- add offline navigation e2e test

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm e2e e2e/offline.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `pnpm exec playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b9d90ac8328ad3d1efe67f923e8