### PR TITLE
feat(redis): allow optional redis configuration

### DIFF
--- a/src/lib/env.server.ts
+++ b/src/lib/env.server.ts
@@ -12,8 +12,8 @@ const envSchema = z.object({
   GITHUB_ID: z.string(),
   GITHUB_SECRET: z.string(),
   AUTH_SECRET: z.string(),
-  UPSTASH_REDIS_URL: z.string().url(),
-  UPSTASH_REDIS_TOKEN: z.string(),
+  UPSTASH_REDIS_URL: z.string().url().optional(),
+  UPSTASH_REDIS_TOKEN: z.string().optional(),
   MATCHMAKING_QUEUE_TTL_SECONDS: z.coerce.number().int().positive().default(60),
   MATCH_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
 })

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -2,7 +2,42 @@ import { Redis } from '@upstash/redis'
 
 import { env } from '@/lib/env.server'
 
-export const redis = new Redis({
-  url: env.UPSTASH_REDIS_URL,
-  token: env.UPSTASH_REDIS_TOKEN,
-})
+function createNoopRedis(): Redis {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'subscribe') {
+          return async () => ({ on: () => {} })
+        }
+        switch (prop) {
+          case 'incr':
+          case 'rpush':
+          case 'expire':
+          case 'publish':
+            return async () => 0
+          case 'set':
+            return async () => 'OK'
+          case 'lpop':
+          case 'lpos':
+            return async () => null
+          default:
+            return async () => undefined
+        }
+      },
+    },
+  ) as Redis
+}
+
+export const redis =
+  env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN
+    ? new Redis({
+        url: env.UPSTASH_REDIS_URL,
+        token: env.UPSTASH_REDIS_TOKEN,
+      })
+    : (() => {
+        console.warn(
+          'Redis disabled: missing UPSTASH_REDIS_URL or UPSTASH_REDIS_TOKEN',
+        )
+        return createNoopRedis()
+      })()


### PR DESCRIPTION
## Summary
- safely skip Redis init when UPSTASH env vars are missing
- make Redis env vars optional in server env schema

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35b9c3ecc8328a5324911e41ddaf5