### PR TITLE
Handle missing Redis configuration gracefully

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -19,6 +19,9 @@ export async function POST(req: Request) {
   if (!session?.user) {
     return error('unauthenticated', 401)
   }
+  if (!redis) {
+    return error('service unavailable', 503)
+  }
   const userId = session.user.id
   try {
     const json = await req.json().catch(() => ({}))

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -23,6 +23,9 @@ const RATE_LIMIT_WINDOW_SECONDS = 60
 const RATE_LIMIT_MAX_REQUESTS = 60
 
 export async function POST(req: Request) {
+  if (!redis) {
+    return error('service unavailable', 503)
+  }
   const ip =
     req.headers.get('x-forwarded-for') ??
     req.headers.get('x-real-ip') ??

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,5 +1,6 @@
 import { redis } from '@/lib/redis'
 
 export function triggerLeaderboardRecalculation() {
+  if (!redis) return
   return redis.publish('leaderboard:recalc', '')
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -2,42 +2,16 @@ import { Redis } from '@upstash/redis'
 
 import { env } from '@/lib/env.server'
 
-function createNoopRedis(): Redis {
-  return new Proxy(
-    {},
-    {
-      get(_target, prop) {
-        if (prop === 'subscribe') {
-          return async () => ({ on: () => {} })
-        }
-        switch (prop) {
-          case 'incr':
-          case 'rpush':
-          case 'expire':
-          case 'publish':
-            return async () => 0
-          case 'set':
-            return async () => 'OK'
-          case 'lpop':
-          case 'lpos':
-            return async () => null
-          default:
-            return async () => undefined
-        }
-      },
-    },
-  ) as Redis
+if (!env.UPSTASH_REDIS_URL || !env.UPSTASH_REDIS_TOKEN) {
+  console.warn(
+    'Redis disabled: missing UPSTASH_REDIS_URL or UPSTASH_REDIS_TOKEN',
+  )
 }
 
-export const redis =
+export const redis: Redis | null =
   env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN
     ? new Redis({
         url: env.UPSTASH_REDIS_URL,
         token: env.UPSTASH_REDIS_TOKEN,
       })
-    : (() => {
-        console.warn(
-          'Redis disabled: missing UPSTASH_REDIS_URL or UPSTASH_REDIS_TOKEN',
-        )
-        return createNoopRedis()
-      })()
+    : null


### PR DESCRIPTION
## Summary
- Export `null` from redis helper when env vars are missing
- Guard API routes and leaderboard worker when Redis isn't configured
- Skip publish when recalculation triggered without Redis

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client'; attempted `pnpm prisma generate` but fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3691396a4832886aad2b1e0da77cc