### PR TITLE
feat: dynamically configure auth providers

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,18 +6,35 @@ import EmailProvider from 'next-auth/providers/email'
 import { prisma } from '@/lib/prisma'
 import { env } from '@/lib/env.server'
 
-export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
-  providers: [
+const providers: NextAuthOptions['providers'] = []
+
+if (env.EMAIL_SERVER && env.EMAIL_FROM) {
+  providers.push(
     EmailProvider({
       server: env.EMAIL_SERVER,
       from: env.EMAIL_FROM,
     }),
+  )
+}
+
+if (env.GITHUB_ID && env.GITHUB_SECRET) {
+  providers.push(
     GithubProvider({
       clientId: env.GITHUB_ID,
       clientSecret: env.GITHUB_SECRET,
     }),
-  ],
+  )
+}
+
+if (providers.length === 0) {
+  throw new Error(
+    'No auth providers configured. Please set EMAIL_* or GITHUB_* environment variables.',
+  )
+}
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers,
   secret: env.AUTH_SECRET,
 }
 


### PR DESCRIPTION
## Summary
- dynamically build NextAuth providers based on available environment variables
- throw descriptive error when no auth providers configured

## Testing
- `pnpm lint` (fails: Unexpected any in src/workers/leaderboard.ts)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36912fa4c8328952897597b52b33a