### PR TITLE
Use typed env for analytics config

### DIFF
--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect } from 'react'
 import { initAnalytics } from '@/lib/analytics'
+import { env } from '@/lib/env.client'
 
 let initialized = false
 
 export function AnalyticsProvider() {
   useEffect(() => {
-    if (!initialized && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    if (!initialized && env.NEXT_PUBLIC_POSTHOG_KEY) {
       initAnalytics()
       initialized = true
     }

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+
+vi.mock('posthog-js', () => ({
+  default: { init: vi.fn() },
+}))
+
+describe('initAnalytics', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('initializes posthog with api_host when host is defined', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'ph_key'
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://app.posthog.com'
+    const posthog = await import('posthog-js')
+    const { initAnalytics } = await import('./analytics')
+
+    initAnalytics()
+
+    expect(posthog.default.init).toHaveBeenCalledWith('ph_key', {
+      api_host: 'https://app.posthog.com',
+    })
+  })
+
+  it('initializes posthog without options when host is undefined', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'ph_key'
+    const posthog = await import('posthog-js')
+    const { initAnalytics } = await import('./analytics')
+
+    initAnalytics()
+
+    expect(posthog.default.init).toHaveBeenCalledWith('ph_key', undefined)
+  })
+})
+

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,7 +6,8 @@ export function initAnalytics() {
   if (typeof window === 'undefined') return
   const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
-  posthog.init(key, {
-    api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
-  })
+  const options = env.NEXT_PUBLIC_POSTHOG_HOST
+    ? { api_host: env.NEXT_PUBLIC_POSTHOG_HOST }
+    : undefined
+  posthog.init(key, options)
 }


### PR DESCRIPTION
## Summary
- use client env to gate AnalyticsProvider initialization
- avoid passing undefined api_host to posthog
- add unit tests for analytics initialization

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a369140be88328b5f650213733ceef