### PR TITLE
feat: handle missing redis in leaderboard worker

### DIFF
--- a/src/workers/leaderboard.ts
+++ b/src/workers/leaderboard.ts
@@ -105,8 +105,9 @@ function reportError(err: unknown, context?: Record<string, unknown>) {
 
 async function main() {
   if (!redis) {
-    console.warn('Redis not configured, exiting leaderboard worker')
-    return
+    console.warn(
+      'Redis not configured, real-time leaderboard updates are disabled',
+    )
   }
   try {
     await recomputeLeaderboard()
@@ -115,7 +116,10 @@ async function main() {
     console.error('Failed to recompute leaderboard', err)
     reportError(err)
   }
-  const sub = redis.subscribe('leaderboard:recalc')
+  if (!redis) {
+    return
+  }
+  const sub = await redis.subscribe('leaderboard:recalc')
   console.log('Subscribed to leaderboard:recalc')
   sub.on('message', async (_, message) => {
     const ctx = { matchId: message }


### PR DESCRIPTION
## Summary
- log when redis is absent and skip real-time leaderboard subscription
- await redis subscription for recalculation updates

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a377f17c848328b0503bb67d9f085f