### PR TITLE
feat(auth): register providers only when env vars present

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,17 +25,20 @@ if (env.GITHUB_ID && env.GITHUB_SECRET) {
     }),
   )
 }
-
 if (providers.length === 0) {
-  throw new Error(
-    'No auth providers configured. Please set EMAIL_* or GITHUB_* environment variables.',
+  console.warn(
+    'No auth providers configured. Continuing without authentication.',
   )
 }
 
-export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
-  providers,
-  secret: env.AUTH_SECRET,
-}
+export const authOptions: NextAuthOptions | undefined =
+  providers.length > 0
+    ? {
+        adapter: PrismaAdapter(prisma),
+        providers,
+        secret: env.AUTH_SECRET,
+      }
+    : undefined
 
-export const getServerAuthSession = () => getServerSession(authOptions)
+export const getServerAuthSession = () =>
+  authOptions ? getServerSession(authOptions) : Promise.resolve(null)


### PR DESCRIPTION
## Summary
- conditionally register NextAuth email and GitHub providers based on env vars
- warn and skip auth setup if no providers configured

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_68a377f018b883288e9eaaf158d84236