### PR TITLE
chore: handle missing redis configuration

### DIFF
--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -15,12 +15,13 @@ export const runtime = 'nodejs'
 const QUEUE_KEY = 'matchmaking:queue'
 
 export async function POST(req: Request) {
+  if (!redis) {
+    return error('service unavailable', 503)
+  }
+
   const session = await getServerAuthSession()
   if (!session?.user) {
     return error('unauthenticated', 401)
-  }
-  if (!redis) {
-    return error('service unavailable', 503)
   }
   const userId = session.user.id
   try {

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -26,6 +26,7 @@ export async function POST(req: Request) {
   if (!redis) {
     return error('service unavailable', 503)
   }
+
   const ip =
     req.headers.get('x-forwarded-for') ??
     req.headers.get('x-real-ip') ??

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,6 +1,9 @@
 import { redis } from '@/lib/redis'
 
 export function triggerLeaderboardRecalculation() {
-  if (!redis) return
+  if (!redis) {
+    return
+  }
+
   return redis.publish('leaderboard:recalc', '')
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -2,16 +2,17 @@ import { Redis } from '@upstash/redis'
 
 import { env } from '@/lib/env.server'
 
-if (!env.UPSTASH_REDIS_URL || !env.UPSTASH_REDIS_TOKEN) {
+let redis: Redis | null = null
+
+if (env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN) {
+  redis = new Redis({
+    url: env.UPSTASH_REDIS_URL,
+    token: env.UPSTASH_REDIS_TOKEN,
+  })
+} else {
   console.warn(
     'Redis disabled: missing UPSTASH_REDIS_URL or UPSTASH_REDIS_TOKEN',
   )
 }
 
-export const redis: Redis | null =
-  env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN
-    ? new Redis({
-        url: env.UPSTASH_REDIS_URL,
-        token: env.UPSTASH_REDIS_TOKEN,
-      })
-    : null
+export { redis }

--- a/src/workers/leaderboard.ts
+++ b/src/workers/leaderboard.ts
@@ -1,6 +1,11 @@
 import { prisma } from '@/lib/prisma'
 import { redis } from '@/lib/redis'
 
+if (!redis) {
+  console.warn('Redis not configured, exiting leaderboard worker')
+  process.exit(0)
+}
+
 interface Stats {
   elo: number
   wins: number
@@ -104,10 +109,6 @@ function reportError(err: unknown, context?: Record<string, unknown>) {
 }
 
 async function main() {
-  if (!redis) {
-    console.warn('Redis not configured, exiting leaderboard worker')
-    return
-  }
   try {
     await recomputeLeaderboard()
     console.log('Recomputed leaderboard')


### PR DESCRIPTION
## Summary
- export `null` when Redis env vars aren't set
- guard leaderboard recalculation and API routes when Redis is unavailable
- exit leaderboard worker if Redis isn't configured

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a377f16318832885525298ce5f31b9