### PR TITLE
feat: add reusable button component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AnalyticsProvider />
-          <header className="p-4 flex gap-2">
+          <header className="flex items-center justify-between gap-2 p-4">
             <AuthButtons />
             <LanguageSwitcher />
             <MuteButton />

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { signIn, signOut, useSession } from 'next-auth/react'
+import { Button } from './ui/Button'
 
 export function AuthButtons() {
   const { data: session } = useSession()
@@ -11,12 +12,18 @@ export function AuthButtons() {
     return (
       <div>
         <span>Signed in as {userLabel}</span>
-        <button onClick={() => signOut()}>Sign out</button>
+        <Button onClick={() => signOut()} variant="primary">
+          Sign out
+        </Button>
       </div>
     )
   }
 
-  return <button onClick={() => signIn()}>Sign in</button>
+  return (
+    <Button onClick={() => signIn()} variant="primary">
+      Sign in
+    </Button>
+  )
 }
 
 export default AuthButtons

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -3,6 +3,7 @@
 import { createNavigation } from 'next-intl/navigation'
 import { useLocale } from 'next-intl'
 import { locales } from '../i18n'
+import { Button } from './ui/Button'
 
 const { usePathname, useRouter } = createNavigation()
 
@@ -14,13 +15,14 @@ export function LanguageSwitcher() {
   return (
     <div className="flex gap-2">
       {locales.map((loc) => (
-        <button
+        <Button
           key={loc}
           onClick={() => router.replace(pathname, { locale: loc })}
+          variant="secondary"
           className={loc === locale ? 'font-bold underline' : ''}
         >
           {loc.toUpperCase()}
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/src/components/MuteButton.tsx
+++ b/src/components/MuteButton.tsx
@@ -2,15 +2,20 @@
 
 import React from 'react'
 import { useSettings } from '../store/settings'
+import { Button } from './ui/Button'
 
 export function MuteButton() {
   const muted = useSettings((s) => s.muted)
   const toggleMuted = useSettings((s) => s.toggleMuted)
 
   return (
-    <button onClick={toggleMuted} aria-label={muted ? 'Unmute' : 'Mute'}>
+    <Button
+      onClick={toggleMuted}
+      aria-label={muted ? 'Unmute' : 'Mute'}
+      variant="secondary"
+    >
       {muted ? 'Unmute' : 'Mute'}
-    </button>
+    </Button>
   )
 }
 

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,25 @@
+import React, { type ButtonHTMLAttributes } from 'react'
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary'
+}
+
+export function Button({
+  variant = 'primary',
+  className = '',
+  ...props
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
+  const variants = {
+    primary:
+      'bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600',
+    secondary:
+      'bg-gray-200 text-gray-900 hover:bg-gray-300 focus-visible:ring-gray-400',
+  }
+  const classes = [base, variants[variant], className].filter(Boolean).join(' ')
+
+  return <button className={classes} {...props} />
+}
+
+export default Button


### PR DESCRIPTION
## Summary
- add Tailwind-based Button component with primary and secondary variants
- use Button across auth, language, and mute controls
- adjust header layout with flex spacing and alignment

## Testing
- `pnpm lint` *(fails: Parsing error: Merge conflict marker encountered in src/lib/analytics.ts)*
- `pnpm typecheck` *(fails: Merge conflict marker encountered in analytics files)*
- `pnpm test` *(fails: Unexpected "===" in src/lib/analytics.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae6058d48328ba00eb2960cc6683