### PR TITLE
Refactor analytics env usage

### DIFF
--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -8,10 +8,12 @@ let initialized = false
 
 export function AnalyticsProvider() {
   useEffect(() => {
-    if (!initialized && env.NEXT_PUBLIC_POSTHOG_KEY) {
+    const key = env.NEXT_PUBLIC_POSTHOG_KEY
+    if (!initialized && key) {
       initAnalytics()
       initialized = true
     }
   }, [])
+
   return null
 }

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,6 +1,12 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-=======
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 const originalEnv = { ...process.env }
 
@@ -9,19 +15,16 @@ vi.mock('posthog-js', () => ({
 }))
 
 describe('initAnalytics', () => {
-  const originalEnv = process.env
-
-=======
   beforeEach(() => {
     vi.resetModules()
     process.env = { ...originalEnv }
+    vi.unstubAllGlobals()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-=======
   afterAll(() => {
     process.env = originalEnv
   })
@@ -32,7 +35,7 @@ describe('initAnalytics', () => {
     const { initAnalytics } = await import('./analytics')
     vi.stubGlobal('window', {})
     initAnalytics()
-    expect(posthog.init).toHaveBeenCalledWith('test-key')
+    expect(posthog.init).toHaveBeenCalledWith('test-key', undefined)
   })
 
   it('initializes analytics with key and host', async () => {
@@ -45,28 +48,5 @@ describe('initAnalytics', () => {
     expect(posthog.init).toHaveBeenCalledWith('test-key', {
       api_host: 'https://test.host',
     })
-=======
-  it('initializes posthog with api_host when host is defined', async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'ph_key'
-    process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://app.posthog.com'
-    const posthog = await import('posthog-js')
-    const { initAnalytics } = await import('./analytics')
-
-    initAnalytics()
-
-    expect(posthog.default.init).toHaveBeenCalledWith('ph_key', {
-      api_host: 'https://app.posthog.com',
-    })
-  })
-
-  it('initializes posthog without options when host is undefined', async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'ph_key'
-    const posthog = await import('posthog-js')
-    const { initAnalytics } = await import('./analytics')
-
-    initAnalytics()
-
-    expect(posthog.default.init).toHaveBeenCalledWith('ph_key', undefined)
   })
 })
-

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,14 +6,10 @@ export function initAnalytics() {
   if (typeof window === 'undefined') return
   const key = env.NEXT_PUBLIC_POSTHOG_KEY
   if (!key) return
-  if (env.NEXT_PUBLIC_POSTHOG_HOST) {
-    posthog.init(key, { api_host: env.NEXT_PUBLIC_POSTHOG_HOST })
-  } else {
-    posthog.init(key)
-  }
-=======
+
   const options = env.NEXT_PUBLIC_POSTHOG_HOST
     ? { api_host: env.NEXT_PUBLIC_POSTHOG_HOST }
     : undefined
+
   posthog.init(key, options)
 }


### PR DESCRIPTION
## Summary
- read PostHog key from env client in AnalyticsProvider
- guard PostHog host before passing api_host option
- update analytics tests for conditional host handling

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae5f3ab48328b921aeb34c13a802