### PR TITLE
feat: add match chat API and client

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Match {
   p2Score   Int
   winner    User?    @relation("MatchWinner", fields: [winnerId], references: [id])
   winnerId  String?
+  chat      MatchChat[]
 }
 
 model Leaderboard {
@@ -50,6 +51,18 @@ model Leaderboard {
   streak    Int    @default(0)
   updatedAt DateTime @updatedAt
   @@index([elo])
+}
+
+model MatchChat {
+  id        String   @id @default(cuid())
+  match     Match    @relation(fields: [matchId], references: [id])
+  matchId   String
+  sender    User     @relation(fields: [senderId], references: [id])
+  senderId  String
+  message   String
+  createdAt DateTime @default(now())
+
+  @@index([matchId])
 }
 
 model Telemetry {

--- a/src/app/api/chat/[matchId]/route.test.ts
+++ b/src/app/api/chat/[matchId]/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    match: { findUnique: vi.fn() },
+    matchChat: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getServerAuthSession: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    channel: () => ({
+      send: vi.fn().mockResolvedValue({}),
+    }),
+  }),
+}))
+
+import { prisma } from '@/lib/prisma'
+import { getServerAuthSession } from '@/lib/auth'
+import { POST } from './route'
+
+const user = { id: 'user1' }
+
+describe('chat API', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('rejects non participants', async () => {
+    ;(getServerAuthSession as unknown as vi.Mock).mockResolvedValue({ user })
+    ;(prisma.match.findUnique as unknown as vi.Mock).mockResolvedValue({
+      p1Id: 'other',
+      p2Id: 'someone',
+    })
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'hi' }),
+    })
+    const res = await POST(req, { params: { matchId: 'match1' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('allows participants', async () => {
+    ;(getServerAuthSession as unknown as vi.Mock).mockResolvedValue({ user })
+    ;(prisma.match.findUnique as unknown as vi.Mock).mockResolvedValue({
+      p1Id: 'user1',
+      p2Id: 'user2',
+    })
+    ;(prisma.matchChat.create as unknown as vi.Mock).mockResolvedValue({
+      id: 'msg1',
+      message: 'hi',
+      createdAt: new Date(),
+    })
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'hi' }),
+    })
+    const res = await POST(req, { params: { matchId: 'match1' } })
+    expect(res.status).toBe(200)
+    expect(prisma.matchChat.create).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/chat/[matchId]/route.ts
+++ b/src/app/api/chat/[matchId]/route.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod'
+import { createClient } from '@supabase/supabase-js'
+
+import { getServerAuthSession } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { env } from '@/lib/env.server'
+import { ok, error } from '@/lib/api-response'
+
+const bodySchema = z.object({
+  message: z.string().min(1).max(500),
+})
+
+export async function POST(
+  req: Request,
+  { params }: { params: { matchId: string } },
+) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return error('unauthorized', 401)
+  }
+
+  const match = await prisma.match.findUnique({
+    where: { id: params.matchId },
+    select: { p1Id: true, p2Id: true },
+  })
+
+  if (!match) {
+    return error('not found', 404)
+  }
+  if (session.user.id !== match.p1Id && session.user.id !== match.p2Id) {
+    return error('forbidden', 403)
+  }
+
+  const json = await req.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return error('invalid', 400)
+  }
+
+  const db = prisma as unknown as {
+    matchChat: {
+      create: (args: {
+        data: {
+          matchId: string
+          senderId: string
+          message: string
+        }
+      }) => Promise<{
+        id: string
+        message: string
+        createdAt: Date
+      }>
+    }
+  }
+
+  const created = await db.matchChat.create({
+    data: {
+      matchId: params.matchId,
+      senderId: session.user.id,
+      message: parsed.data.message,
+    },
+  })
+
+  if (env.NEXT_PUBLIC_SUPABASE_URL && env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    const supabase = createClient(
+      env.NEXT_PUBLIC_SUPABASE_URL,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    )
+    await supabase.channel(`chat:${params.matchId}`).send({
+      type: 'broadcast',
+      event: 'message',
+      payload: {
+        id: created.id,
+        userId: session.user.id,
+        message: created.message,
+        createdAt: created.createdAt.toISOString(),
+      },
+    })
+  }
+
+  return ok({ ok: true })
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { matchId: string } },
+) {
+  const session = await getServerAuthSession()
+  if (!session?.user) {
+    return error('unauthorized', 401)
+  }
+  const match = await prisma.match.findUnique({
+    where: { id: params.matchId },
+    select: { p1Id: true, p2Id: true },
+  })
+  if (!match) {
+    return error('not found', 404)
+  }
+  if (session.user.id !== match.p1Id && session.user.id !== match.p2Id) {
+    return error('forbidden', 403)
+  }
+
+  const db = prisma as unknown as {
+    matchChat: {
+      findMany: (args: {
+        where: { matchId: string }
+        orderBy: { createdAt: 'asc' }
+      }) => Promise<unknown[]>
+    }
+  }
+
+  const messages = await db.matchChat.findMany({
+    where: { matchId: params.matchId },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  return ok(messages)
+}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useState, FormEvent } from 'react'
+
+import { supabase } from '@/lib/supabase'
+import { logTelemetry } from '@/lib/analytics'
+
+interface Message {
+  id: string
+  userId: string
+  message: string
+  createdAt: string
+}
+
+export function ChatPanel({ matchId }: { matchId: string }) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/chat/${matchId}`)
+      if (res.ok) {
+        const data = (await res.json()) as Message[]
+        setMessages(data)
+      }
+    }
+    load()
+  }, [matchId])
+
+  useEffect(() => {
+    if (!supabase) return
+    const channel = supabase
+      .channel(`chat:${matchId}`)
+      .on('broadcast', { event: 'message' }, ({ payload }) => {
+        setMessages((prev) => [...prev, payload as Message])
+      })
+      .subscribe()
+    return () => {
+      channel.unsubscribe()
+    }
+  }, [matchId])
+
+  async function send(e: FormEvent) {
+    e.preventDefault()
+    const text = input.trim()
+    if (!text) return
+    setInput('')
+    await fetch(`/api/chat/${matchId}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: text }),
+    })
+    logTelemetry('match_chat', { matchId })
+  }
+
+  return (
+    <div>
+      <div>
+        {messages.map((m) => (
+          <div key={m.id}>
+            <strong>{m.userId}</strong>: {m.message}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={send}>
+        <input value={input} onChange={(e) => setInput(e.target.value)} />
+      </form>
+    </div>
+  )
+}

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -50,3 +50,23 @@ describe('initAnalytics', () => {
     })
   })
 })
+
+describe('logTelemetry', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts telemetry event', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetch)
+    const { logTelemetry } = await import('./analytics')
+    await logTelemetry('match_chat', { matchId: '1' })
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/telemetry',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -13,3 +13,18 @@ export function initAnalytics() {
 
   posthog.init(key, options)
 }
+
+export async function logTelemetry(
+  eventType: string,
+  payload: Record<string, unknown>,
+) {
+  try {
+    await fetch('/api/telemetry', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ eventType, payload }),
+    })
+  } catch (err) {
+    console.warn('telemetry failed', err)
+  }
+}


### PR DESCRIPTION
## Summary
- add match chat API with participant validation and Supabase broadcast
- track chat telemetry and expose ChatPanel component
- record chat messages in new MatchChat model

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c0ff6bf483289934edc9c330b3c6