### PR TITLE
feat: support ranked match mode

### DIFF
--- a/prisma/migrations/20250813000000_add_match_mode_enum/migration.sql
+++ b/prisma/migrations/20250813000000_add_match_mode_enum/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "MatchMode" AS ENUM ('classic', 'ranked');
+
+-- AlterTable
+ALTER TABLE "Match" ALTER COLUMN "mode" TYPE "MatchMode" USING "mode"::"MatchMode";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum MatchMode {
+  classic
+  ranked
+}
+
 model User {
   id         String       @id @default(cuid())
   email      String       @unique
@@ -30,7 +35,7 @@ model Match {
   id        String   @id @default(cuid())
   startedAt DateTime @default(now())
   endedAt   DateTime?
-  mode      String
+  mode      MatchMode
   p1        User     @relation("MatchP1", fields: [p1Id], references: [id])
   p1Id      String
   p2        User?    @relation("MatchP2", fields: [p2Id], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -27,7 +27,7 @@ async function main() {
 
   await prisma.match.create({
     data: {
-      mode: 'singleplayer',
+      mode: 'classic',
       p1Id: alice.id,
       p2Id: bob.id,
       p1Score: 11,

--- a/src/app/api/matchmaking/route.test.ts
+++ b/src/app/api/matchmaking/route.test.ts
@@ -17,7 +17,7 @@ describe('matchmaking API', () => {
     vi.mocked(redis.lpop).mockResolvedValueOnce(null)
     vi.mocked(redis.lpos).mockResolvedValueOnce(null)
 
-    const res = await POST(jsonRequest({ mode: 'classic' }))
+    const res = await POST(jsonRequest({ mode: 'ranked' }))
     const json = await res.json()
 
     expect(res.status).toBe(200)
@@ -31,7 +31,7 @@ describe('matchmaking API', () => {
     vi.mocked(redis.lpop).mockResolvedValueOnce('u1')
     vi.mocked(redis.lpos).mockResolvedValueOnce(0)
 
-    const res = await POST(jsonRequest({ mode: 'classic' }))
+    const res = await POST(jsonRequest({ mode: 'ranked' }))
     const json = await res.json()
 
     expect(res.status).toBe(200)
@@ -47,13 +47,13 @@ describe('matchmaking API', () => {
       id: 'm1',
     } as unknown as { id: string })
 
-    const res = await POST(jsonRequest({ mode: 'classic' }))
+    const res = await POST(jsonRequest({ mode: 'ranked' }))
     const json = await res.json()
 
     expect(res.status).toBe(200)
     expect(json).toEqual({ p1: 'u1', p2: 'u2', matchId: 'm1' })
     expect(prisma.match.create).toHaveBeenCalledWith({
-      data: { p1Id: 'u1', p2Id: 'u2', mode: 'classic', p1Score: 0, p2Score: 0 },
+      data: { p1Id: 'u1', p2Id: 'u2', mode: 'ranked', p1Score: 0, p2Score: 0 },
     })
     expect(redis.set).toHaveBeenCalledWith(
       'match:m1',

--- a/src/app/api/matchmaking/route.ts
+++ b/src/app/api/matchmaking/route.ts
@@ -7,7 +7,7 @@ import { env } from '@/lib/env.server'
 import { ok, error } from '@/lib/api-response'
 
 const bodySchema = z.object({
-  mode: z.enum(['classic']).default('classic'),
+  mode: z.enum(['classic', 'ranked']).default('classic'),
 })
 
 export const runtime = 'nodejs'

--- a/src/app/api/score/route.test.ts
+++ b/src/app/api/score/route.test.ts
@@ -30,6 +30,7 @@ describe('score API', () => {
       p1Id: 'p1',
       p2Id: 'p2',
       endedAt: null,
+      mode: 'classic',
     })
 
     const body = {
@@ -74,6 +75,7 @@ describe('score API', () => {
       p1Id: 'p1',
       p2Id: 'p2',
       endedAt: null,
+      mode: 'classic',
     })
 
     const body = {
@@ -97,6 +99,7 @@ describe('score API', () => {
       p1Id: 'p1',
       p2Id: 'p2',
       endedAt: new Date(),
+      mode: 'classic',
     })
 
     const body = {
@@ -120,6 +123,7 @@ describe('score API', () => {
       p1Id: 'p1',
       p2Id: 'p2',
       endedAt: null,
+      mode: 'classic',
     })
 
     const body = {
@@ -137,6 +141,14 @@ describe('score API', () => {
   })
 
   it('returns 500 on update failure', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: 'p1' } })
+    prisma.match.findUnique.mockResolvedValue({
+      id: 'm1',
+      p1Id: 'p1',
+      p2Id: 'p2',
+      endedAt: null,
+      mode: 'classic',
+    })
     const body = {
       matchId: 'm1',
       p1Score: 10,

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -38,6 +38,11 @@ export async function POST(req: Request) {
     if (p1Score === p2Score) {
       return error('invalid-score', 400)
     }
+
+    const targetScore = match.mode === 'ranked' ? 15 : 10
+    if (p1Score < targetScore && p2Score < targetScore) {
+      return error('invalid-score', 400)
+    }
     const winnerId = p1Score > p2Score ? match.p1Id : match.p2Id
     await prisma.match.update({
       where: { id: matchId },

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -2,10 +2,16 @@
 
 import { GameCanvas } from '@/components/GameCanvas'
 
-export default function MatchPage({ params }: { params: { id: string } }) {
+export default function MatchPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string }
+  searchParams: { mode?: 'classic' | 'ranked' }
+}) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-8">
-      <GameCanvas matchId={params.id} />
+      <GameCanvas matchId={params.id} mode={searchParams.mode} />
     </main>
   )
 }

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -5,10 +5,16 @@ import { useEffect, useRef } from 'react'
 import { usePhaserGame } from '../hooks/usePhaserGame'
 import { useSettings } from '../store/settings'
 
-export function GameCanvas({ matchId }: { matchId?: string }) {
+export function GameCanvas({
+  matchId,
+  mode,
+}: {
+  matchId?: string
+  mode?: 'classic' | 'ranked'
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const muted = useSettings((s) => s.muted)
-  const gameRef = usePhaserGame(containerRef, muted, matchId)
+  const gameRef = usePhaserGame(containerRef, muted, matchId, mode)
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -15,17 +15,20 @@ export default class MainScene extends Phaser.Scene {
   private velocity = new Phaser.Math.Vector2(200, 200)
   private paddleSpeed = 300
   private paddleHeight = 100
-  private score = new ScoreManager()
+  private score: ScoreManager
   private matchId?: string
+  private mode: 'classic' | 'ranked'
   private channel?: RealtimeChannel
   private remotePaddleY: number | null = null
   private remoteBall: { x: number; y: number; vx: number; vy: number } | null =
     null
   private lastRemoteUpdate = 0
 
-  constructor(matchId?: string) {
+  constructor(matchId?: string, mode: 'classic' | 'ranked' = 'classic') {
     super('MainScene')
     this.matchId = matchId
+    this.mode = mode
+    this.score = new ScoreManager(mode === 'ranked' ? 15 : 10)
   }
 
   preload() {

--- a/src/hooks/usePhaserGame.test.ts
+++ b/src/hooks/usePhaserGame.test.ts
@@ -35,7 +35,7 @@ describe('usePhaserGame', () => {
     const ref = { current: container } as React.RefObject<HTMLDivElement>
 
     const { rerender } = renderHook(
-      ({ muted }) => usePhaserGame(ref, muted, 'match'),
+      ({ muted }) => usePhaserGame(ref, muted, 'match', 'classic'),
       {
         initialProps: { muted: false },
       },
@@ -58,7 +58,9 @@ describe('usePhaserGame', () => {
     const container = document.createElement('div')
     const ref = { current: container } as React.RefObject<HTMLDivElement>
 
-    const { unmount } = renderHook(() => usePhaserGame(ref, false, 'match'))
+    const { unmount } = renderHook(() =>
+      usePhaserGame(ref, false, 'match', 'classic'),
+    )
 
     await waitFor(() => {
       expect(Game).toHaveBeenCalledTimes(1)

--- a/src/hooks/usePhaserGame.ts
+++ b/src/hooks/usePhaserGame.ts
@@ -9,6 +9,7 @@ export function usePhaserGame(
   containerRef: React.RefObject<HTMLDivElement>,
   muted: boolean,
   matchId?: string,
+  mode?: 'classic' | 'ranked',
 ) {
   const gameRef = useRef<PhaserModule.Game | null>(null)
 
@@ -23,7 +24,7 @@ export function usePhaserGame(
           parent: containerRef.current!,
           width: containerRef.current!.clientWidth,
           height: containerRef.current!.clientHeight,
-          scene: new MainScene(matchId),
+          scene: new MainScene(matchId, mode),
         }
         gameRef.current = new Phaser.Game(config)
       }
@@ -31,7 +32,7 @@ export function usePhaserGame(
     }
 
     void init()
-  }, [muted, containerRef, matchId])
+  }, [muted, containerRef, matchId, mode])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- allow multiple matchmaking modes including ranked
- persist match mode in Prisma schema
- pass selected mode through frontend to game logic

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test`
- `pnpm e2e --browser=chromium` *(fails: The "file" argument must be of type string. Received undefined)*
- `pnpm prisma migrate dev` *(fails: Failed to fetch the engine file at ... schema-engine.gz - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0fe74bc83288ad760757ac951ee