### PR TITLE
feat: add spectate streaming

### DIFF
--- a/src/app/api/match/[id]/spectate/route.ts
+++ b/src/app/api/match/[id]/spectate/route.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from 'events'
+
+const emitters = new Map<string, EventEmitter>()
+
+function getEmitter(id: string) {
+  let emitter = emitters.get(id)
+  if (!emitter) {
+    emitter = new EventEmitter()
+    emitters.set(id, emitter)
+  }
+  return emitter
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const emitter = getEmitter(params.id)
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const onUpdate = (state: unknown) => {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(state)}\n\n`))
+      }
+      emitter.on('update', onUpdate)
+      return () => {
+        emitter.off('update', onUpdate)
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const emitter = getEmitter(params.id)
+  const body = await req.json()
+  emitter.emit('update', body)
+  return new Response(null, { status: 204 })
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/match/[id]/spectate/page.tsx
+++ b/src/app/match/[id]/spectate/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface SpectateState {
+  paddleY: number
+  opponentY: number
+  ballX: number
+  ballY: number
+  playerScore: number
+  opponentScore: number
+}
+
+export default function SpectatorView({ params }: { params: { id: string } }) {
+  const [state, setState] = useState<SpectateState>({
+    paddleY: 0,
+    opponentY: 0,
+    ballX: 0,
+    ballY: 0,
+    playerScore: 0,
+    opponentScore: 0,
+  })
+
+  useEffect(() => {
+    const es = new EventSource(`/api/match/${params.id}/spectate`)
+    es.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data)
+        setState((s) => ({ ...s, ...data }))
+      } catch {
+        // ignore malformed data
+      }
+    }
+    return () => {
+      es.close()
+    }
+  }, [params.id])
+
+  return (
+    <div className="relative w-full h-screen bg-black">
+      <div className="absolute top-2 left-1/4 text-white text-2xl">
+        {state.playerScore}
+      </div>
+      <div className="absolute top-2 right-1/4 text-white text-2xl">
+        {state.opponentScore}
+      </div>
+      <div
+        className="absolute bg-white w-2 h-24"
+        style={{ left: '20px', top: state.paddleY - 50 }}
+      />
+      <div
+        className="absolute bg-white w-2 h-24"
+        style={{ right: '20px', top: state.opponentY - 50 }}
+      />
+      <div
+        className="absolute bg-white rounded-full"
+        style={{
+          width: '10px',
+          height: '10px',
+          left: state.ballX,
+          top: state.ballY,
+        }}
+      />
+    </div>
+  )
+}

--- a/src/game/MainScene.ts
+++ b/src/game/MainScene.ts
@@ -22,10 +22,12 @@ export default class MainScene extends Phaser.Scene {
   private remoteBall: { x: number; y: number; vx: number; vy: number } | null =
     null
   private lastRemoteUpdate = 0
+  private spectator = false
 
-  constructor(matchId?: string) {
+  constructor(matchId?: string, spectator = false) {
     super('MainScene')
     this.matchId = matchId
+    this.spectator = spectator
   }
 
   preload() {
@@ -211,5 +213,21 @@ export default class MainScene extends Phaser.Scene {
         velY: this.velocity.y,
       },
     })
+
+    if (this.spectator && this.matchId) {
+      void fetch(`/api/match/${this.matchId}/spectate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          paddleY: this.player.y,
+          opponentY: this.opponent.y,
+          ballX: this.ball.x,
+          ballY: this.ball.y,
+          playerScore: this.score.playerScore,
+          opponentScore: this.score.opponentScore,
+        }),
+        keepalive: true,
+      })
+    }
   }
 }

--- a/src/hooks/usePhaserGame.ts
+++ b/src/hooks/usePhaserGame.ts
@@ -23,7 +23,7 @@ export function usePhaserGame(
           parent: containerRef.current!,
           width: containerRef.current!.clientWidth,
           height: containerRef.current!.clientHeight,
-          scene: new MainScene(matchId),
+          scene: new MainScene(matchId, Boolean(matchId)),
         }
         gameRef.current = new Phaser.Game(config)
       }


### PR DESCRIPTION
## Summary
- expose SSE endpoint for match spectating
- broadcast minimal game state when spectator flag is enabled
- add basic spectator view consuming SSE stream

## Testing
- `pnpm typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `pnpm test` *(0 tests run; all files queued)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1002e9c8328943d538734a58a91